### PR TITLE
Implement server authoritative crumbs economy

### DIFF
--- a/spec/economy_spec.lua
+++ b/spec/economy_spec.lua
@@ -1,0 +1,66 @@
+package.path = "src/server/?.luau;src/server/?/init.luau;src/shared/?.luau;src/shared/?/init.luau;" .. package.path
+
+local Economy = require("Economy")
+local Config = require("Config")
+
+local function newPlayer()
+    return {
+        id = 1,
+        crumbs = 0,
+        inventory = {},
+        upgrades = {},
+        aether = {
+            current = 0,
+            target = 20,
+            decayRate = 0.08,
+            purityBase = 0.55,
+        },
+        timestamps = {},
+    }
+end
+
+-- Selling Aether acceptance test
+local player = newPlayer()
+player.aether.current = 40
+local gain = Economy.SellAether(player)
+assert(gain == 176, "expected 176 gain")
+assert(player.aether.current == 0, "aether not reset")
+assert(player.crumbs == 176, "crumbs not updated")
+
+-- Selling item polished_crystal
+local player2 = newPlayer()
+player2.inventory.polished_crystal = 2
+local gain2 = Economy.SellItem(player2, "polished_crystal", 2)
+assert(gain2 == 300, "expected gain 300")
+assert(player2.inventory.polished_crystal == 0, "inventory not reduced")
+assert(player2.crumbs == 300, "crumbs not updated")
+
+-- Attempt to sell with zero aether
+local player3 = newPlayer()
+local gain3 = Economy.SellAether(player3)
+assert(gain3 == 0, "gain should be 0")
+assert(player3.crumbs == 0, "crumbs should remain 0")
+
+-- Attempt with bad reason
+local player4 = newPlayer()
+local ok = Economy.ApplyCrumbsDelta(player4, 10, "hack")
+assert(ok == false, "bad reason should be rejected")
+assert(player4.crumbs == 0, "crumbs should not change")
+
+-- Rate limit exceed
+local player5 = newPlayer()
+for i=1,10 do
+    assert(Economy.ApplyCrumbsDelta(player5, 1, "grant"))
+end
+assert(Economy.ApplyCrumbsDelta(player5, 1, "grant") == false, "11th update should fail")
+
+-- Purchase upgrade
+local player6 = newPlayer()
+player6.crumbs = 200
+local success = Economy.PurchaseUpgrade(player6, "purity_plus005")
+assert(success, "purchase should succeed")
+assert(player6.crumbs == 0, "cost should be deducted")
+assert(player6.aether.purityBase > 0.55, "purityBase should increase")
+assert(player6.upgrades.purity_plus005 == true, "upgrade recorded")
+
+print("All tests passed!")

--- a/src/server/Economy.luau
+++ b/src/server/Economy.luau
@@ -1,0 +1,136 @@
+local ok, Config = pcall(function()
+    local ReplicatedStorage = game:GetService("ReplicatedStorage")
+    return require(ReplicatedStorage:WaitForChild("shared"):WaitForChild("Config"))
+end)
+if not ok then
+    Config = require("Config")
+end
+
+local MAX_DELTA = 1e9
+local RATE_WINDOW = 5
+local RATE_MAX = 10
+
+local rateLimits = {}
+local lastAetherSell = {}
+
+local function clamp(value, min, max)
+    if value < min then
+        return min
+    end
+    if value > max then
+        return max
+    end
+    return value
+end
+
+local Economy = {}
+
+function Economy.ApplyCrumbsDelta(player, delta, reason)
+    if not Config.ReasonWhitelist[reason] then
+        return false
+    end
+    if math.abs(delta) > MAX_DELTA then
+        return false
+    end
+    local now = os.clock()
+    local bucket = rateLimits[player] or {}
+    local newBucket = {}
+    for _, t in ipairs(bucket) do
+        if now - t < RATE_WINDOW then
+            table.insert(newBucket, t)
+        end
+    end
+    if #newBucket >= RATE_MAX then
+        rateLimits[player] = newBucket
+        return false
+    end
+    table.insert(newBucket, now)
+    rateLimits[player] = newBucket
+
+    player.crumbs = (player.crumbs or 0) + delta
+    print("ApplyCrumbsDelta", player.id or "unknown", delta, reason)
+    return true
+end
+
+function Economy.SellAether(player)
+    local aether = player.aether or {}
+    local current = aether.current or 0
+    if current <= 0 then
+        return 0
+    end
+    local now = os.clock()
+    local last = lastAetherSell[player]
+    if last and now - last < 0.5 then
+        return 0
+    end
+    local purityBase = aether.purityBase or 0
+    local purity = clamp(purityBase, 0.10, 1.00)
+    local gain = math.floor(current * purity * 8)
+    if gain <= 0 then
+        return 0
+    end
+    local success = Economy.ApplyCrumbsDelta(player, gain, "sell_aether")
+    if success then
+        aether.current = 0
+        lastAetherSell[player] = now
+        return gain
+    end
+    return 0
+end
+
+function Economy.SellItem(player, itemId, qty)
+    if qty <= 0 then
+        return 0
+    end
+    local item = Config.ItemById[itemId]
+    if not item then
+        return 0
+    end
+    local inv = player.inventory or {}
+    local have = inv[itemId] or 0
+    if have < qty then
+        return 0
+    end
+    local gain = item.sell_value * qty
+    inv[itemId] = have - qty
+    local success = Economy.ApplyCrumbsDelta(player, gain, "sell_item")
+    if not success then
+        inv[itemId] = have
+        return 0
+    end
+    return gain
+end
+
+function Economy.PurchaseUpgrade(player, upgradeId)
+    local upgrade = Config.UpgradeById[upgradeId]
+    if not upgrade then
+        return false
+    end
+    local prereq = upgrade.prereq
+    if prereq and not player.upgrades[prereq] then
+        return false
+    end
+    if player.upgrades[upgradeId] then
+        return false
+    end
+    local cost = upgrade.cost
+    if player.crumbs < cost then
+        return false
+    end
+    local ok = Economy.ApplyCrumbsDelta(player, -cost, "purchase")
+    if not ok then
+        return false
+    end
+    local aether = player.aether
+    if upgrade.affects == "target" then
+        aether.target = (aether.target or 0) + upgrade.value
+    elseif upgrade.affects == "purityBase" then
+        aether.purityBase = (aether.purityBase or 0) + upgrade.value
+    elseif upgrade.affects == "decayRate" then
+        aether.decayRate = (aether.decayRate or 0) + upgrade.value
+    end
+    player.upgrades[upgradeId] = true
+    return true
+end
+
+return Economy

--- a/src/server/init.server.luau
+++ b/src/server/init.server.luau
@@ -1,1 +1,3 @@
+local Economy = require(script.Parent:WaitForChild("Economy"))
+
 print("Hello world, from server!")

--- a/src/shared/Config.luau
+++ b/src/shared/Config.luau
@@ -1,0 +1,35 @@
+local Config = {}
+
+Config.ReasonWhitelist = {
+    sell_aether = true,
+    sell_item = true,
+    purchase = true,
+    refund = true,
+    grant = true,
+}
+
+Config.ItemConfig = {
+    { id = "shiny_pebble", displayName = "Shiny Pebble", sell_value = 10, stackable = true },
+    { id = "copper_nugget", displayName = "Copper Nugget", sell_value = 20, stackable = true },
+    { id = "silver_chunk", displayName = "Silver Chunk", sell_value = 50, stackable = true },
+    { id = "gold_ingot", displayName = "Gold Ingot", sell_value = 100, stackable = true },
+    { id = "polished_crystal", displayName = "Polished Crystal", sell_value = 150, stackable = true },
+}
+
+Config.ItemById = {}
+for _, item in ipairs(Config.ItemConfig) do
+    Config.ItemById[item.id] = item
+end
+
+Config.UpgradeConfig = {
+    { id = "target_plus10", affects = "target", value = 10, cost = 100 },
+    { id = "purity_plus005", affects = "purityBase", value = 0.05, cost = 200 },
+    { id = "decay_minus001", affects = "decayRate", value = -0.01, cost = 150 },
+}
+
+Config.UpgradeById = {}
+for _, up in ipairs(Config.UpgradeConfig) do
+    Config.UpgradeById[up.id] = up
+end
+
+return Config


### PR DESCRIPTION
## Summary
- add Config for items, upgrades and reason whitelist
- implement server-side Economy module with crumbs delta, selling aether/items, and upgrades
- load economy service on server init

## Testing
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_689c935b4ca08327b2391e9074f09f77