### PR TITLE
feat: simplify aether accrual and snapshot flow

### DIFF
--- a/spec/aether_spec.lua
+++ b/spec/aether_spec.lua
@@ -1,5 +1,11 @@
 package.path = "src/server/?.luau;src/server/?/init.luau;src/shared/?.luau;src/shared/?/init.luau;" .. package.path
 
+if not time then
+    function time()
+        return os.clock()
+    end
+end
+
 local Aether = require("Aether")
 local Config = require("Config")
 
@@ -16,7 +22,7 @@ local function newPlayer()
             decayRate = 0.08,
             purityBase = 0.55,
             totalRate = 0,
-            lastSettleTs = os.time(),
+            lastSettleTs = time(),
         },
         producers = {},
         timestamps = {},
@@ -26,7 +32,7 @@ end
 -- Test 1: Offline settle - growth to target
 local player1 = newPlayer()
 player1.aether.totalRate = 1
-player1.aether.lastSettleTs = os.time() - 25
+player1.aether.lastSettleTs = time() - 25
 Aether.Settle(player1)
 assert(math.abs(player1.aether.current - 20) < 0.01, "Should reach target after 25s")
 
@@ -35,7 +41,7 @@ local player2 = newPlayer()
 player2.aether.current = 50
 player2.aether.target = 20
 player2.aether.decayRate = 0.08
-player2.aether.lastSettleTs = os.time() - 5
+player2.aether.lastSettleTs = time() - 5
 Aether.Settle(player2)
 local expected = 20 + 30 * math.exp(-0.08 * 5)
 assert(math.abs(player2.aether.current - expected) < 0.01, "Overfill decay incorrect")

--- a/spec/economy_spec.lua
+++ b/spec/economy_spec.lua
@@ -1,5 +1,11 @@
 package.path = "src/server/?.luau;src/server/?/init.luau;src/shared/?.luau;src/shared/?/init.luau;" .. package.path
 
+if not time then
+    function time()
+        return os.clock()
+    end
+end
+
 local Economy = require("Economy")
 local Config = require("Config")
 

--- a/src/client/AetherClient.luau
+++ b/src/client/AetherClient.luau
@@ -8,7 +8,6 @@ local playerGui = player:WaitForChild("PlayerGui")
 
 -- Wait for RemoteEvents
 local aetherSnapshot = ReplicatedStorage:WaitForChild("Aether_Snapshot")
-local aetherChanged = ReplicatedStorage:WaitForChild("Aether_Changed")
 local aetherRequestSell = ReplicatedStorage:WaitForChild("Aether_RequestSell")
 
 local AetherClient = {}
@@ -17,11 +16,11 @@ local AetherClient = {}
 local aetherState = {
 	current = 0,
 	target = 20,
-	totalRate = 0,
-	decayRate = 0.08,
-	purityBase = 0.55,
-	lastUpdateTime = tick(),
-	serverSynced = false
+        totalRate = 0,
+        decayRate = 0.08,
+        purityBase = 0.55,
+        lastUpdateTime = time(),
+        serverSynced = false
 }
 
 local function clamp(value, min, max)
@@ -50,8 +49,8 @@ local function settleAether(dt)
 		current = math.min(aetherState.target, current + aetherState.totalRate * dt)
 	end
 	
-	aetherState.current = current
-	aetherState.lastUpdateTime = tick()
+        aetherState.current = current
+        aetherState.lastUpdateTime = time()
 end
 
 -- Calculate projected crumbs
@@ -276,26 +275,9 @@ aetherSnapshot.OnClientEvent:Connect(function(serverData)
 	aetherState.totalRate = serverData.totalRate
 	aetherState.decayRate = serverData.decayRate
 	aetherState.purityBase = serverData.purityBase
-	aetherState.lastUpdateTime = tick()
-	aetherState.serverSynced = true
+        aetherState.lastUpdateTime = serverData.serverNow
+        aetherState.serverSynced = true
 	
-	updateUI()
-end)
-
--- Handle server change events
-aetherChanged.OnClientEvent:Connect(function(changeData)
-	-- Apply delta changes from server
-	if changeData.currentDelta then
-		aetherState.current = aetherState.current + changeData.currentDelta
-	end
-	if changeData.targetDelta then
-		aetherState.target = aetherState.target + changeData.targetDelta
-	end
-	if changeData.totalRate ~= nil then
-		aetherState.totalRate = changeData.totalRate
-	end
-	
-	aetherState.lastUpdateTime = tick()
 	updateUI()
 end)
 
@@ -305,7 +287,7 @@ local function onHeartbeat()
 		return
 	end
 	
-	local now = tick()
+        local now = time()
 	local dt = now - aetherState.lastUpdateTime
 	
 	if dt > 0.01 then -- Update at most 100 times per second

--- a/src/server/Aether.luau
+++ b/src/server/Aether.luau
@@ -1,5 +1,14 @@
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local HttpService = game:GetService("HttpService")
+local ok, ReplicatedStorage = pcall(function()
+    return game:GetService("ReplicatedStorage")
+end)
+local okHttp, HttpServiceInst = pcall(function()
+    return game:GetService("HttpService")
+end)
+local HttpService = okHttp and HttpServiceInst or {
+    GenerateGUID = function()
+        return tostring(math.random(1, 1e8))
+    end
+}
 
 local Aether = {}
 
@@ -21,11 +30,11 @@ local function CalcEffectiveRate(producer)
 end
 
 function Aether.Settle(player, now)
-    now = now or tick()
+    now = now or time()
     local aether = player.aether
-    local dt = math.max(0, now - aether.lastSettleTs)
-    
-    if dt <= 0 then
+    local dt = now - aether.lastSettleTs
+
+    if dt <= 1e-4 then
         return
     end
     
@@ -62,7 +71,7 @@ function Aether.Init(player)
             decayRate = 0.08,
             purityBase = 0.55,
             totalRate = 0,
-            lastSettleTs = tick(),
+            lastSettleTs = time(),
         }
     end
     if not player.producers then
@@ -156,13 +165,27 @@ end
 
 function Aether.RequestSell(player)
     Aether.Settle(player)
-    local Economy = require(script.Parent:WaitForChild("Economy"))
-    return Economy.SellAether(player)
+    local Economy
+    if script and script.Parent then
+        Economy = require(script.Parent:WaitForChild("Economy"))
+    else
+        Economy = require("Economy")
+    end
+    local gain = Economy.SellAether(player)
+    local aether = player.aether
+    aether.current = 0
+    aether.lastSettleTs = time()
+    return gain
 end
 
 function Aether.ApplyUpgrade(player, upgradeId)
     Aether.Settle(player)
-    local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+    local Config
+    if ReplicatedStorage then
+        Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+    else
+        Config = require("Config")
+    end
     local upgrade = Config.UpgradeById[upgradeId]
     
     if not upgrade then
@@ -188,7 +211,7 @@ function Aether.Snapshot(player)
         totalRate = player.aether.totalRate,
         decayRate = player.aether.decayRate,
         purityBase = player.aether.purityBase,
-        serverNow = tick(),
+        serverNow = time(),
     }
 end
 

--- a/src/server/DebugCommands.luau
+++ b/src/server/DebugCommands.luau
@@ -1,7 +1,9 @@
 local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
 local Economy = require(script.Parent:WaitForChild("Economy"))
 local Aether = require(script.Parent:WaitForChild("Aether"))
+local aetherSnapshot = ReplicatedStorage:WaitForChild("Aether_Snapshot")
 
 local DebugCommands = {}
 
@@ -64,6 +66,7 @@ function DebugCommands.AddProducer(playerName, producerType, baseRate, patchId)
     local data = PlayerManager.GetPlayerData(player)
     local uid, debugName = Aether.AddProducer(data, producerType, baseRate, patchId)
     PlayerManager.SavePlayerData(player, data)
+    aetherSnapshot:FireClient(player, Aether.Snapshot(data))
     print("Added producer", debugName, "(UID:", uid .. ") to", playerName)
     return uid, debugName
 end
@@ -78,6 +81,7 @@ function DebugCommands.RemoveProducer(playerName, uid)
     local success = Aether.RemoveProducer(data, uid)
     if success then
         PlayerManager.SavePlayerData(player, data)
+        aetherSnapshot:FireClient(player, Aether.Snapshot(data))
         print("Removed producer", uid, "from", playerName)
     else
         print("Producer not found:", uid)
@@ -95,6 +99,7 @@ function DebugCommands.SetProducerActive(playerName, uid, active)
     local success = Aether.SetProducerActive(data, uid, active)
     if success then
         PlayerManager.SavePlayerData(player, data)
+        aetherSnapshot:FireClient(player, Aether.Snapshot(data))
         print("Set producer", uid, "active to", active, "for", playerName)
     else
         print("Producer not found:", uid)
@@ -112,6 +117,7 @@ function DebugCommands.SetProducerRate(playerName, uid, baseRate, addBonus, mult
     local success = Aether.SetProducerRate(data, uid, baseRate, addBonus, multBonus)
     if success then
         PlayerManager.SavePlayerData(player, data)
+        aetherSnapshot:FireClient(player, Aether.Snapshot(data))
         print("Updated producer", uid, "rates for", playerName)
     else
         print("Producer not found:", uid)
@@ -169,6 +175,7 @@ function DebugCommands.SetTarget(playerName, value)
     Aether.Settle(data)
     data.aether.target = value
     PlayerManager.SavePlayerData(player, data)
+    aetherSnapshot:FireClient(player, Aether.Snapshot(data))
     print("Set", playerName, "aether target to", value)
     return true
 end
@@ -183,6 +190,7 @@ function DebugCommands.SetDecay(playerName, value)
     Aether.Settle(data)
     data.aether.decayRate = value
     PlayerManager.SavePlayerData(player, data)
+    aetherSnapshot:FireClient(player, Aether.Snapshot(data))
     print("Set", playerName, "aether decay rate to", value)
     return true
 end
@@ -197,6 +205,7 @@ function DebugCommands.SetPurity(playerName, value)
     Aether.Settle(data)
     data.aether.purityBase = value
     PlayerManager.SavePlayerData(player, data)
+    aetherSnapshot:FireClient(player, Aether.Snapshot(data))
     print("Set", playerName, "aether purity base to", value)
     return true
 end
@@ -210,6 +219,7 @@ function DebugCommands.Burst(playerName, value)
     local data = PlayerManager.GetPlayerData(player)
     Aether.ApplyBurst(data, value)
     PlayerManager.SavePlayerData(player, data)
+    aetherSnapshot:FireClient(player, Aether.Snapshot(data))
     print("Added", value, "aether burst to", playerName, "- New total:", data.aether.current)
     return true
 end

--- a/src/server/Economy.luau
+++ b/src/server/Economy.luau
@@ -72,6 +72,7 @@ function Economy.SellAether(player)
     local success = Economy.ApplyCrumbsDelta(player, gain, "sell_aether")
     if success then
         aether.current = 0
+        aether.lastSettleTs = time()
         lastAetherSell[player] = now
         return gain
     end

--- a/src/server/PlayerManager.luau
+++ b/src/server/PlayerManager.luau
@@ -16,7 +16,7 @@ local function createNewPlayerData(player)
             decayRate = 0.08,
             purityBase = 0.55,
             totalRate = 0,
-            lastSettleTs = os.time(),
+            lastSettleTs = time(),
         },
         producers = {},
         timestamps = {},

--- a/src/server/init.server.luau
+++ b/src/server/init.server.luau
@@ -39,10 +39,6 @@ local aetherSnapshot = Instance.new("RemoteEvent")
 aetherSnapshot.Name = "Aether_Snapshot"
 aetherSnapshot.Parent = ReplicatedStorage
 
-local aetherChanged = Instance.new("RemoteEvent")
-aetherChanged.Name = "Aether_Changed"
-aetherChanged.Parent = ReplicatedStorage
-
 local aetherRequestSell = Instance.new("RemoteFunction")
 aetherRequestSell.Name = "Aether_RequestSell"
 aetherRequestSell.Parent = ReplicatedStorage
@@ -66,11 +62,10 @@ sellAether.OnServerInvoke = function(player)
     local data = PlayerManager.GetPlayerData(player)
     local gain = Economy.SellAether(data)
     PlayerManager.SavePlayerData(player, data)
-    
-    -- Fire aether changed event
+
     local aetherData = Aether.Snapshot(data)
-    aetherChanged:FireClient(player, aetherData)
-    
+    aetherSnapshot:FireClient(player, aetherData)
+
     return gain, data.crumbs
 end
 
@@ -86,11 +81,11 @@ purchaseUpgrade.OnServerInvoke = function(player, upgradeId)
     local success = Economy.PurchaseUpgrade(data, upgradeId)
     PlayerManager.SavePlayerData(player, data)
     
-    -- Apply aether upgrade and fire changed event if successful
+    -- Apply aether upgrade and send snapshot if successful
     if success then
         Aether.ApplyUpgrade(data, upgradeId)
         local aetherData = Aether.Snapshot(data)
-        aetherChanged:FireClient(player, aetherData)
+        aetherSnapshot:FireClient(player, aetherData)
     end
     
     return success, data.crumbs
@@ -108,11 +103,10 @@ aetherRequestSell.OnServerInvoke = function(player)
     local data = PlayerManager.GetPlayerData(player)
     local gain = Aether.RequestSell(data)
     PlayerManager.SavePlayerData(player, data)
-    
-    -- Fire aether changed event after sell
+
     local aetherData = Aether.Snapshot(data)
-    aetherChanged:FireClient(player, aetherData)
-    
+    aetherSnapshot:FireClient(player, aetherData)
+
     return gain, data.crumbs
 end
 
@@ -136,12 +130,14 @@ spawnProducer.OnServerInvoke = function(player)
     -- Add producer to aether system
     local uid = Aether.AddProducer(data, "Spawned", 0.5)
     PlayerManager.SavePlayerData(player, data)
+    aetherSnapshot:FireClient(player, Aether.Snapshot(data))
     
     -- Make it clickable to remove
     clickDetector.MouseClick:Connect(function(clickingPlayer)
         if clickingPlayer == player then
             Aether.RemoveProducer(data, uid)
             PlayerManager.SavePlayerData(player, data)
+            aetherSnapshot:FireClient(player, Aether.Snapshot(data))
             producer:Destroy()
             print("Removed producer", uid)
         end
@@ -168,7 +164,7 @@ local function runAetherTest()
             decayRate = 0.08,
             purityBase = 0.55,
             totalRate = 0,
-            lastSettleTs = os.time(),
+            lastSettleTs = time(),
         },
         producers = {},
         timestamps = {},
@@ -188,7 +184,7 @@ local function runAetherTest()
     
     -- Test 3: Wait and settle (simulate 5 seconds)
     print("3. Simulating 5 seconds of growth...")
-    testPlayer.aether.lastSettleTs = os.time() - 5
+    testPlayer.aether.lastSettleTs = time() - 5
     Aether.Settle(testPlayer)
     print("   After 5s - Current:", testPlayer.aether.current)
     


### PR DESCRIPTION
## Summary
- remove server heartbeat in favor of lazy-settled aether using timestamps
- send fresh Aether_Snapshot after sells, upgrades, and producer edits
- drop Aether_Changed remote; client listens only to snapshots and interpolates locally

## Testing
- `lua spec/economy_spec.lua`
- `lua spec/aether_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_689d58fe6c5c832791a71769a41de462