### PR TITLE
refactor: initialize remotes before debug commands

### DIFF
--- a/src/server/DebugCommands.luau
+++ b/src/server/DebugCommands.luau
@@ -3,9 +3,15 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
 local Economy = require(script.Parent:WaitForChild("Economy"))
 local Aether = require(script.Parent:WaitForChild("Aether"))
-local aetherSnapshot = ReplicatedStorage:WaitForChild("Aether_Snapshot")
 
 local DebugCommands = {}
+local aetherSnapshot
+
+-- Allows init.server to provide the remote once it's created, avoiding
+-- WaitForChild calls during module load and preventing circular waits.
+function DebugCommands.SetAetherSnapshot(remote)
+    aetherSnapshot = remote
+end
 
 function DebugCommands.GetPlayerMoney(playerName)
     local player = Players:FindFirstChild(playerName)

--- a/src/server/init.server.luau
+++ b/src/server/init.server.luau
@@ -1,15 +1,7 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-print("Loading Economy...")
-local Economy = require(script:WaitForChild("Economy"))
-print("Loading Aether...")
-local Aether = require(script:WaitForChild("Aether"))
-print("Loading PlayerManager...")
-local PlayerManager = require(script:WaitForChild("PlayerManager"))
-print("Loading DebugCommands...")
-local DebugCommands = require(script:WaitForChild("DebugCommands"))
-print("All modules loaded!")
-
+-- RemoteEvents and RemoteFunctions are created before requiring modules to
+-- avoid circular waits when modules like DebugCommands expect them at load time.
 local getPlayerData = Instance.new("RemoteFunction")
 getPlayerData.Name = "GetPlayerData"
 getPlayerData.Parent = ReplicatedStorage
@@ -46,6 +38,19 @@ aetherRequestSell.Parent = ReplicatedStorage
 local aetherReachedCapacity = Instance.new("RemoteEvent")
 aetherReachedCapacity.Name = "Aether_ReachedCapacity"
 aetherReachedCapacity.Parent = ReplicatedStorage
+
+print("Loading Economy...")
+local Economy = require(script:WaitForChild("Economy"))
+print("Loading Aether...")
+local Aether = require(script:WaitForChild("Aether"))
+print("Loading PlayerManager...")
+local PlayerManager = require(script:WaitForChild("PlayerManager"))
+print("Loading DebugCommands...")
+local DebugCommands = require(script:WaitForChild("DebugCommands"))
+if DebugCommands.SetAetherSnapshot then
+    DebugCommands.SetAetherSnapshot(aetherSnapshot)
+end
+print("All modules loaded!")
 
 getPlayerData.OnServerInvoke = function(player)
     local data = PlayerManager.GetPlayerData(player)


### PR DESCRIPTION
## Summary
- Create remotes before loading server modules to avoid `WaitForChild` deadlocks
- Allow `DebugCommands` to receive the `Aether_Snapshot` remote from the server initializer

## Testing
- `lua spec/economy_spec.lua`
- `rojo build -o "skyhunters.rbxlx"`
- `aftman install` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_689d5daea260832784d05c0e9573320b