### PR TITLE
feat: add lever sell interaction and snapshot payload

### DIFF
--- a/spec/aether_spec.lua
+++ b/spec/aether_spec.lua
@@ -1,5 +1,11 @@
 package.path = "src/server/?.luau;src/server/?/init.luau;src/shared/?.luau;src/shared/?/init.luau;" .. package.path
 
+if not time then
+    function time()
+        return os.clock()
+    end
+end
+
 local Aether = require("Aether")
 local Config = require("Config")
 
@@ -16,7 +22,7 @@ local function newPlayer()
             decayRate = 0.08,
             purityBase = 0.55,
             totalRate = 0,
-            lastSettleTs = os.time(),
+            lastSettleTs = time(),
         },
         producers = {},
         timestamps = {},
@@ -26,7 +32,7 @@ end
 -- Test 1: Offline settle - growth to target
 local player1 = newPlayer()
 player1.aether.totalRate = 1
-player1.aether.lastSettleTs = os.time() - 25
+player1.aether.lastSettleTs = time() - 25
 Aether.Settle(player1)
 assert(math.abs(player1.aether.current - 20) < 0.01, "Should reach target after 25s")
 
@@ -35,7 +41,7 @@ local player2 = newPlayer()
 player2.aether.current = 50
 player2.aether.target = 20
 player2.aether.decayRate = 0.08
-player2.aether.lastSettleTs = os.time() - 5
+player2.aether.lastSettleTs = time() - 5
 Aether.Settle(player2)
 local expected = 20 + 30 * math.exp(-0.08 * 5)
 assert(math.abs(player2.aether.current - expected) < 0.01, "Overfill decay incorrect")

--- a/spec/economy_spec.lua
+++ b/spec/economy_spec.lua
@@ -1,5 +1,11 @@
 package.path = "src/server/?.luau;src/server/?/init.luau;src/shared/?.luau;src/shared/?/init.luau;" .. package.path
 
+if not time then
+    function time()
+        return os.clock()
+    end
+end
+
 local Economy = require("Economy")
 local Config = require("Config")
 

--- a/src/client/AetherClient.luau
+++ b/src/client/AetherClient.luau
@@ -1,15 +1,12 @@
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RunService = game:GetService("RunService")
-local TweenService = game:GetService("TweenService")
 
 local player = Players.LocalPlayer
 local playerGui = player:WaitForChild("PlayerGui")
 
 -- Wait for RemoteEvents
 local aetherSnapshot = ReplicatedStorage:WaitForChild("Aether_Snapshot")
-local aetherChanged = ReplicatedStorage:WaitForChild("Aether_Changed")
-local aetherRequestSell = ReplicatedStorage:WaitForChild("Aether_RequestSell")
 
 local AetherClient = {}
 
@@ -17,22 +14,12 @@ local AetherClient = {}
 local aetherState = {
 	current = 0,
 	target = 20,
-	totalRate = 0,
-	decayRate = 0.08,
-	purityBase = 0.55,
-	lastUpdateTime = tick(),
-	serverSynced = false
+        totalRate = 0,
+        decayRate = 0.08,
+        purityBase = 0.55,
+        lastUpdateTime = time(),
+        serverSynced = false
 }
-
-local function clamp(value, min, max)
-	if value < min then
-		return min
-	end
-	if value > max then
-		return max
-	end
-	return value
-end
 
 -- Client-side settle math (mirrors server logic)
 local function settleAether(dt)
@@ -50,14 +37,8 @@ local function settleAether(dt)
 		current = math.min(aetherState.target, current + aetherState.totalRate * dt)
 	end
 	
-	aetherState.current = current
-	aetherState.lastUpdateTime = tick()
-end
-
--- Calculate projected crumbs
-local function getProjectedCrumbs()
-	local purity = clamp(aetherState.purityBase, 0.10, 1.00)
-	return math.floor(aetherState.current * purity * 8)
+        aetherState.current = current
+        aetherState.lastUpdateTime = time()
 end
 
 -- UI Creation
@@ -163,52 +144,15 @@ local function createAetherGauge()
 	rateText.TextXAlignment = Enum.TextXAlignment.Left
 	rateText.Parent = frame
 	
-	-- Sell button
-	local sellButton = Instance.new("TextButton")
-	sellButton.Name = "SellButton"
-	sellButton.Size = UDim2.new(0, 60, 0, 20)
-	sellButton.Position = UDim2.new(1, -70, 0, 95)
-	sellButton.BackgroundColor3 = Color3.new(0.2, 0.6, 0.2)
-	sellButton.Text = "SELL"
-	sellButton.TextColor3 = Color3.new(1, 1, 1)
-	sellButton.Font = Enum.Font.SourceSansBold
-	sellButton.TextSize = 10
-	sellButton.Parent = frame
-	
-	-- Tooltip frame (initially hidden)
-	local tooltip = Instance.new("Frame")
-	tooltip.Name = "Tooltip"
-	tooltip.Size = UDim2.new(0, 100, 0, 25)
-	tooltip.Position = UDim2.new(0, -105, 0, 95)
-	tooltip.BackgroundColor3 = Color3.new(0, 0, 0)
-	tooltip.BackgroundTransparency = 0.2
-	tooltip.BorderSizePixel = 1
-	tooltip.BorderColor3 = Color3.new(0.5, 0.5, 0.5)
-	tooltip.Visible = false
-	tooltip.Parent = sellButton
-	
-	local tooltipText = Instance.new("TextLabel")
-	tooltipText.Name = "Text"
-	tooltipText.Size = UDim2.new(1, 0, 1, 0)
-	tooltipText.BackgroundTransparency = 1
-	tooltipText.Text = "₡0"
-	tooltipText.TextColor3 = Color3.new(1, 1, 1)
-	tooltipText.Font = Enum.Font.SourceSans
-	tooltipText.TextSize = 10
-	tooltipText.Parent = tooltip
-	
-	return {
-		frame = frame,
-		fillBar = fillBar,
-		overfillBar = overfillBar,
-		targetLine = targetLine,
-		currentText = currentText,
-		targetText = targetText,
-		rateText = rateText,
-		sellButton = sellButton,
-		tooltip = tooltip,
-		tooltipText = tooltipText
-	}
+        return {
+                frame = frame,
+                fillBar = fillBar,
+                overfillBar = overfillBar,
+                targetLine = targetLine,
+                currentText = currentText,
+                targetText = targetText,
+                rateText = rateText,
+        }
 end
 
 local ui = createAetherGauge()
@@ -239,64 +183,21 @@ local function updateUI()
 		ui.fillBar.BackgroundColor3 = Color3.new(0.3, 0.7, 1) -- Normal blue
 	end
 	
-	-- Update tooltip with projected crumbs
-	local projectedCrumbs = getProjectedCrumbs()
-	ui.tooltipText.Text = "₡" .. projectedCrumbs
 end
 
--- Tooltip hover events
-ui.sellButton.MouseEnter:Connect(function()
-	ui.tooltip.Visible = true
-end)
-
-ui.sellButton.MouseLeave:Connect(function()
-	ui.tooltip.Visible = false
-end)
-
--- Sell button functionality
-ui.sellButton.MouseButton1Click:Connect(function()
-	local success, gain = pcall(function()
-		return aetherRequestSell:InvokeServer()
-	end)
-	
-	if success and gain > 0 then
-		print("Sold aether for", gain, "crumbs")
-		aetherState.current = 0 -- Immediately update local state
-		updateUI()
-	else
-		print("Failed to sell aether")
-	end
-end)
-
 -- Handle server snapshots
-aetherSnapshot.OnClientEvent:Connect(function(serverData)
-	print("Received aether snapshot:", serverData.current, "/", serverData.target, "rate:", serverData.totalRate)
-	aetherState.current = serverData.current
-	aetherState.target = serverData.target
-	aetherState.totalRate = serverData.totalRate
-	aetherState.decayRate = serverData.decayRate
-	aetherState.purityBase = serverData.purityBase
-	aetherState.lastUpdateTime = tick()
-	aetherState.serverSynced = true
-	
-	updateUI()
-end)
+aetherSnapshot.OnClientEvent:Connect(function(payload)
+        local serverData = payload.aether or payload
+        print("Received aether snapshot:", serverData.current, "/", serverData.target, "rate:", serverData.totalRate)
+        aetherState.current = serverData.current
+        aetherState.target = serverData.target
+        aetherState.totalRate = serverData.totalRate
+        aetherState.decayRate = serverData.decayRate
+        aetherState.purityBase = serverData.purityBase
+        aetherState.lastUpdateTime = serverData.serverNow
+        aetherState.serverSynced = true
 
--- Handle server change events
-aetherChanged.OnClientEvent:Connect(function(changeData)
-	-- Apply delta changes from server
-	if changeData.currentDelta then
-		aetherState.current = aetherState.current + changeData.currentDelta
-	end
-	if changeData.targetDelta then
-		aetherState.target = aetherState.target + changeData.targetDelta
-	end
-	if changeData.totalRate ~= nil then
-		aetherState.totalRate = changeData.totalRate
-	end
-	
-	aetherState.lastUpdateTime = tick()
-	updateUI()
+        updateUI()
 end)
 
 -- Main update loop for client-side prediction
@@ -305,7 +206,7 @@ local function onHeartbeat()
 		return
 	end
 	
-	local now = tick()
+        local now = time()
 	local dt = now - aetherState.lastUpdateTime
 	
 	if dt > 0.01 then -- Update at most 100 times per second
@@ -317,11 +218,7 @@ end
 RunService.Heartbeat:Connect(onHeartbeat)
 
 AetherClient.GetCurrentAether = function()
-	return aetherState.current
-end
-
-AetherClient.GetProjectedCrumbs = function()
-	return getProjectedCrumbs()
+        return aetherState.current
 end
 
 return AetherClient

--- a/src/client/init.client.luau
+++ b/src/client/init.client.luau
@@ -4,6 +4,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local player = Players.LocalPlayer
 local playerGui = player:WaitForChild("PlayerGui")
 
+local aetherSnapshot = ReplicatedStorage:WaitForChild("Aether_Snapshot")
 ReplicatedStorage:WaitForChild("GetPlayerData")
 
 local screenGui = Instance.new("ScreenGui")
@@ -35,6 +36,10 @@ crumbsLabel.TextColor3 = Color3.new(1, 1, 1)
 crumbsLabel.Font = Enum.Font.SourceSans
 crumbsLabel.TextSize = 14
 crumbsLabel.Parent = frame
+
+aetherSnapshot.OnClientEvent:Connect(function(payload)
+    crumbsLabel.Text = "₡" .. (payload.crumbs or 0)
+end)
 
 local function createButton(text, position, callback)
     local button = Instance.new("TextButton")

--- a/src/server/Aether.luau
+++ b/src/server/Aether.luau
@@ -1,5 +1,14 @@
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local HttpService = game:GetService("HttpService")
+local ok, ReplicatedStorage = pcall(function()
+    return game:GetService("ReplicatedStorage")
+end)
+local okHttp, HttpServiceInst = pcall(function()
+    return game:GetService("HttpService")
+end)
+local HttpService = okHttp and HttpServiceInst or {
+    GenerateGUID = function()
+        return tostring(math.random(1, 1e8))
+    end
+}
 
 local Aether = {}
 
@@ -21,11 +30,11 @@ local function CalcEffectiveRate(producer)
 end
 
 function Aether.Settle(player, now)
-    now = now or tick()
+    now = now or time()
     local aether = player.aether
-    local dt = math.max(0, now - aether.lastSettleTs)
-    
-    if dt <= 0 then
+    local dt = now - aether.lastSettleTs
+
+    if dt <= 1e-4 then
         return
     end
     
@@ -62,7 +71,7 @@ function Aether.Init(player)
             decayRate = 0.08,
             purityBase = 0.55,
             totalRate = 0,
-            lastSettleTs = tick(),
+            lastSettleTs = time(),
         }
     end
     if not player.producers then
@@ -156,13 +165,27 @@ end
 
 function Aether.RequestSell(player)
     Aether.Settle(player)
-    local Economy = require(script.Parent:WaitForChild("Economy"))
-    return Economy.SellAether(player)
+    local Economy
+    if script and script.Parent then
+        Economy = require(script.Parent:WaitForChild("Economy"))
+    else
+        Economy = require("Economy")
+    end
+    local gain = Economy.SellAether(player)
+    local aether = player.aether
+    aether.current = 0
+    aether.lastSettleTs = time()
+    return gain
 end
 
 function Aether.ApplyUpgrade(player, upgradeId)
     Aether.Settle(player)
-    local Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+    local Config
+    if ReplicatedStorage then
+        Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
+    else
+        Config = require("Config")
+    end
     local upgrade = Config.UpgradeById[upgradeId]
     
     if not upgrade then
@@ -188,7 +211,14 @@ function Aether.Snapshot(player)
         totalRate = player.aether.totalRate,
         decayRate = player.aether.decayRate,
         purityBase = player.aether.purityBase,
-        serverNow = tick(),
+        serverNow = time(),
+    }
+end
+
+function Aether.Payload(player)
+    return {
+        aether = Aether.Snapshot(player),
+        crumbs = player.crumbs,
     }
 end
 

--- a/src/server/DebugCommands.luau
+++ b/src/server/DebugCommands.luau
@@ -1,7 +1,13 @@
 local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
 local Economy = require(script.Parent:WaitForChild("Economy"))
 local Aether = require(script.Parent:WaitForChild("Aether"))
+local aetherSnapshot = ReplicatedStorage:WaitForChild("Aether_Snapshot")
+
+local function sendSnapshot(player, data)
+    aetherSnapshot:FireClient(player, Aether.Payload(data))
+end
 
 local DebugCommands = {}
 
@@ -25,6 +31,7 @@ function DebugCommands.SetPlayerMoney(playerName, amount)
     local data = PlayerManager.GetPlayerData(player)
     data.crumbs = amount
     PlayerManager.SavePlayerData(player, data)
+    sendSnapshot(player, data)
     print("Set", playerName, "crumbs to", amount)
     return true
 end
@@ -39,6 +46,7 @@ function DebugCommands.AddPlayerMoney(playerName, amount)
     local success = Economy.ApplyCrumbsDelta(data, amount, "grant")
     if success then
         PlayerManager.SavePlayerData(player, data)
+        sendSnapshot(player, data)
         print("Added", amount, "crumbs to", playerName, "- New total:", data.crumbs)
     else
         print("Failed to add crumbs to", playerName)
@@ -64,6 +72,7 @@ function DebugCommands.AddProducer(playerName, producerType, baseRate, patchId)
     local data = PlayerManager.GetPlayerData(player)
     local uid, debugName = Aether.AddProducer(data, producerType, baseRate, patchId)
     PlayerManager.SavePlayerData(player, data)
+    sendSnapshot(player, data)
     print("Added producer", debugName, "(UID:", uid .. ") to", playerName)
     return uid, debugName
 end
@@ -78,6 +87,7 @@ function DebugCommands.RemoveProducer(playerName, uid)
     local success = Aether.RemoveProducer(data, uid)
     if success then
         PlayerManager.SavePlayerData(player, data)
+        sendSnapshot(player, data)
         print("Removed producer", uid, "from", playerName)
     else
         print("Producer not found:", uid)
@@ -95,6 +105,7 @@ function DebugCommands.SetProducerActive(playerName, uid, active)
     local success = Aether.SetProducerActive(data, uid, active)
     if success then
         PlayerManager.SavePlayerData(player, data)
+        sendSnapshot(player, data)
         print("Set producer", uid, "active to", active, "for", playerName)
     else
         print("Producer not found:", uid)
@@ -112,6 +123,7 @@ function DebugCommands.SetProducerRate(playerName, uid, baseRate, addBonus, mult
     local success = Aether.SetProducerRate(data, uid, baseRate, addBonus, multBonus)
     if success then
         PlayerManager.SavePlayerData(player, data)
+        sendSnapshot(player, data)
         print("Updated producer", uid, "rates for", playerName)
     else
         print("Producer not found:", uid)
@@ -169,6 +181,7 @@ function DebugCommands.SetTarget(playerName, value)
     Aether.Settle(data)
     data.aether.target = value
     PlayerManager.SavePlayerData(player, data)
+    sendSnapshot(player, data)
     print("Set", playerName, "aether target to", value)
     return true
 end
@@ -183,6 +196,7 @@ function DebugCommands.SetDecay(playerName, value)
     Aether.Settle(data)
     data.aether.decayRate = value
     PlayerManager.SavePlayerData(player, data)
+    sendSnapshot(player, data)
     print("Set", playerName, "aether decay rate to", value)
     return true
 end
@@ -197,6 +211,7 @@ function DebugCommands.SetPurity(playerName, value)
     Aether.Settle(data)
     data.aether.purityBase = value
     PlayerManager.SavePlayerData(player, data)
+    sendSnapshot(player, data)
     print("Set", playerName, "aether purity base to", value)
     return true
 end
@@ -210,6 +225,7 @@ function DebugCommands.Burst(playerName, value)
     local data = PlayerManager.GetPlayerData(player)
     Aether.ApplyBurst(data, value)
     PlayerManager.SavePlayerData(player, data)
+    sendSnapshot(player, data)
     print("Added", value, "aether burst to", playerName, "- New total:", data.aether.current)
     return true
 end

--- a/src/server/Economy.luau
+++ b/src/server/Economy.luau
@@ -72,6 +72,7 @@ function Economy.SellAether(player)
     local success = Economy.ApplyCrumbsDelta(player, gain, "sell_aether")
     if success then
         aether.current = 0
+        aether.lastSettleTs = time()
         lastAetherSell[player] = now
         return gain
     end

--- a/src/server/PlayerManager.luau
+++ b/src/server/PlayerManager.luau
@@ -16,7 +16,7 @@ local function createNewPlayerData(player)
             decayRate = 0.08,
             purityBase = 0.55,
             totalRate = 0,
-            lastSettleTs = os.time(),
+            lastSettleTs = time(),
         },
         producers = {},
         timestamps = {},

--- a/src/server/init.server.luau
+++ b/src/server/init.server.luau
@@ -1,4 +1,5 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TweenService = game:GetService("TweenService")
 
 print("Loading Economy...")
 local Economy = require(script:WaitForChild("Economy"))
@@ -39,10 +40,6 @@ local aetherSnapshot = Instance.new("RemoteEvent")
 aetherSnapshot.Name = "Aether_Snapshot"
 aetherSnapshot.Parent = ReplicatedStorage
 
-local aetherChanged = Instance.new("RemoteEvent")
-aetherChanged.Name = "Aether_Changed"
-aetherChanged.Parent = ReplicatedStorage
-
 local aetherRequestSell = Instance.new("RemoteFunction")
 aetherRequestSell.Name = "Aether_RequestSell"
 aetherRequestSell.Parent = ReplicatedStorage
@@ -51,14 +48,17 @@ local aetherReachedCapacity = Instance.new("RemoteEvent")
 aetherReachedCapacity.Name = "Aether_ReachedCapacity"
 aetherReachedCapacity.Parent = ReplicatedStorage
 
+local function sendSnapshot(player, data)
+    aetherSnapshot:FireClient(player, Aether.Payload(data))
+end
+
 getPlayerData.OnServerInvoke = function(player)
     local data = PlayerManager.GetPlayerData(player)
-    
+
     -- Send aether snapshot when player gets data
-    local aetherData = Aether.Snapshot(data)
-    print("Sending aether snapshot to", player.Name, "- Current:", aetherData.current, "Target:", aetherData.target)
-    aetherSnapshot:FireClient(player, aetherData)
-    
+    print("Sending aether snapshot to", player.Name)
+    sendSnapshot(player, data)
+
     return data
 end
 
@@ -66,11 +66,7 @@ sellAether.OnServerInvoke = function(player)
     local data = PlayerManager.GetPlayerData(player)
     local gain = Economy.SellAether(data)
     PlayerManager.SavePlayerData(player, data)
-    
-    -- Fire aether changed event
-    local aetherData = Aether.Snapshot(data)
-    aetherChanged:FireClient(player, aetherData)
-    
+    sendSnapshot(player, data)
     return gain, data.crumbs
 end
 
@@ -78,6 +74,7 @@ sellItem.OnServerInvoke = function(player, itemId, qty)
     local data = PlayerManager.GetPlayerData(player)
     local gain = Economy.SellItem(data, itemId, qty)
     PlayerManager.SavePlayerData(player, data)
+    sendSnapshot(player, data)
     return gain, data.crumbs
 end
 
@@ -85,14 +82,13 @@ purchaseUpgrade.OnServerInvoke = function(player, upgradeId)
     local data = PlayerManager.GetPlayerData(player)
     local success = Economy.PurchaseUpgrade(data, upgradeId)
     PlayerManager.SavePlayerData(player, data)
-    
-    -- Apply aether upgrade and fire changed event if successful
+
+    -- Apply aether upgrade and send snapshot if successful
     if success then
         Aether.ApplyUpgrade(data, upgradeId)
-        local aetherData = Aether.Snapshot(data)
-        aetherChanged:FireClient(player, aetherData)
+        sendSnapshot(player, data)
     end
-    
+
     return success, data.crumbs
 end
 
@@ -100,6 +96,7 @@ debugAddCrumbs.OnServerInvoke = function(player, amount)
     local data = PlayerManager.GetPlayerData(player)
     local success = Economy.ApplyCrumbsDelta(data, amount, "grant")
     PlayerManager.SavePlayerData(player, data)
+    sendSnapshot(player, data)
     return success, data.crumbs
 end
 
@@ -108,11 +105,7 @@ aetherRequestSell.OnServerInvoke = function(player)
     local data = PlayerManager.GetPlayerData(player)
     local gain = Aether.RequestSell(data)
     PlayerManager.SavePlayerData(player, data)
-    
-    -- Fire aether changed event after sell
-    local aetherData = Aether.Snapshot(data)
-    aetherChanged:FireClient(player, aetherData)
-    
+    sendSnapshot(player, data)
     return gain, data.crumbs
 end
 
@@ -136,12 +129,14 @@ spawnProducer.OnServerInvoke = function(player)
     -- Add producer to aether system
     local uid = Aether.AddProducer(data, "Spawned", 0.5)
     PlayerManager.SavePlayerData(player, data)
+    sendSnapshot(player, data)
     
     -- Make it clickable to remove
     clickDetector.MouseClick:Connect(function(clickingPlayer)
         if clickingPlayer == player then
             Aether.RemoveProducer(data, uid)
             PlayerManager.SavePlayerData(player, data)
+            sendSnapshot(player, data)
             producer:Destroy()
             print("Removed producer", uid)
         end
@@ -168,7 +163,7 @@ local function runAetherTest()
             decayRate = 0.08,
             purityBase = 0.55,
             totalRate = 0,
-            lastSettleTs = os.time(),
+            lastSettleTs = time(),
         },
         producers = {},
         timestamps = {},
@@ -188,7 +183,7 @@ local function runAetherTest()
     
     -- Test 3: Wait and settle (simulate 5 seconds)
     print("3. Simulating 5 seconds of growth...")
-    testPlayer.aether.lastSettleTs = os.time() - 5
+    testPlayer.aether.lastSettleTs = time() - 5
     Aether.Settle(testPlayer)
     print("   After 5s - Current:", testPlayer.aether.current)
     
@@ -234,6 +229,56 @@ local function createAetherCanister()
 end
 
 createAetherCanister()
+
+-- Create lever for selling aether
+local function createSellLever()
+    local workspace = game:GetService("Workspace")
+
+    local model = Instance.new("Model")
+    model.Name = "SellLever"
+    model.Parent = workspace
+
+    local base = Instance.new("Part")
+    base.Name = "Base"
+    base.Size = Vector3.new(2, 1, 2)
+    base.Anchored = true
+    base.Position = Vector3.new(6, 0.5, 0)
+    base.Color = Color3.new(0.4, 0.4, 0.4)
+    base.Parent = model
+
+    local handle = Instance.new("Part")
+    handle.Name = "Handle"
+    handle.Size = Vector3.new(0.5, 3, 0.5)
+    handle.Anchored = true
+    handle.Position = Vector3.new(6, 2, 0)
+    handle.Color = Color3.new(0.8, 0.2, 0.2)
+    handle.Parent = model
+
+    local prompt = Instance.new("ProximityPrompt")
+    prompt.ActionText = "Sell Aether"
+    prompt.ObjectText = "Lever"
+    prompt.HoldDuration = 1
+    prompt.Parent = handle
+
+    local initialCF = handle.CFrame
+    prompt.Triggered:Connect(function(player)
+        local downTween = TweenService:Create(handle, TweenInfo.new(0.35, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {CFrame = initialCF * CFrame.Angles(0, 0, math.rad(-45))})
+        local upTween = TweenService:Create(handle, TweenInfo.new(0.55, Enum.EasingStyle.Quad, Enum.EasingDirection.InOut), {CFrame = initialCF})
+        downTween:Play()
+        downTween.Completed:Connect(function()
+            upTween:Play()
+        end)
+
+        local data = PlayerManager.GetPlayerData(player)
+        Aether.RequestSell(data)
+        PlayerManager.SavePlayerData(player, data)
+        sendSnapshot(player, data)
+    end)
+
+    print("Created sell lever at (6,0,0)")
+end
+
+createSellLever()
 
 -- Run test 2 seconds after server starts
 wait(2)


### PR DESCRIPTION
## Summary
- send combined aether/money snapshot from server
- add world lever with ProximityPrompt to sell aether
- update debug UI and client to consume snapshots

## Testing
- `lua spec/aether_spec.lua`
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_689d58fe6c5c832791a71769a41de462