### PR TITLE
Defer DebugCommands initialization until remotes exist

### DIFF
--- a/src/server/DebugCommands.luau
+++ b/src/server/DebugCommands.luau
@@ -1,9 +1,7 @@
 local Players = game:GetService("Players")
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
 local Economy = require(script.Parent:WaitForChild("Economy"))
 local Aether = require(script.Parent:WaitForChild("Aether"))
-local aetherSnapshot = ReplicatedStorage:WaitForChild("Aether_Snapshot")
 
 local DebugCommands = {}
 local aetherSnapshot

--- a/src/server/init.server.luau
+++ b/src/server/init.server.luau
@@ -40,6 +40,13 @@ local aetherReachedCapacity = Instance.new("RemoteEvent")
 aetherReachedCapacity.Name = "Aether_ReachedCapacity"
 aetherReachedCapacity.Parent = ReplicatedStorage
 
+local Economy = require(script:WaitForChild("Economy"))
+local Aether = require(script:WaitForChild("Aether"))
+local PlayerManager = require(script:WaitForChild("PlayerManager"))
+local DebugCommands = require(script:WaitForChild("DebugCommands"))
+
+DebugCommands.SetAetherSnapshot(aetherSnapshot)
+
 local function sendSnapshot(player, data)
     local payload = {
         aether = Aether.Snapshot(data),


### PR DESCRIPTION
## Summary
- Accept Aether_Snapshot via DebugCommands.SetAetherSnapshot and remove top-level WaitForChild
- Require server modules after creating remotes and pass snapshot remote to DebugCommands

## Testing
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_689d726879a0832797c78f580579e243