### PR TITLE
Refine inventory paging and UI cell pooling

### DIFF
--- a/spec/inventory_spec.lua
+++ b/spec/inventory_spec.lua
@@ -6,16 +6,17 @@ end
 
 local InventoryBridge = require("InventoryBridge")
 
-local items, cursor, total = InventoryBridge.GetPage({}, "producers")
-assert(type(items) == "table" and #items > 0, "GetPage returns items")
+local player = {}
 
-local filtered = InventoryBridge.GetPage({}, "producers", "Item 1")
-for _, item in ipairs(filtered) do
-    assert(string.find(item.name, "Item 1"), "search filters names")
-end
+local items, cursor, total = InventoryBridge.GetPage(player, "producers")
+assert(#items == 0 and total == 0, "Empty inventory returns no items")
+
+local newItem = InventoryBridge._giveSampleItem(player, "producers", 1)
+items, cursor, total = InventoryBridge.GetPage(player, "producers")
+assert(#items == 1 and total == 1, "New items appear when added")
 
 local first = items[1]
-assert(InventoryBridge.Equip({}, first.uid) == true, "Equip existing item")
-assert(InventoryBridge.Equip({}, "nope") == false, "Equip returns false for missing")
+assert(InventoryBridge.Equip(player, first.uid) == true, "Equip existing item")
+assert(InventoryBridge.Equip(player, "nope") == false, "Equip returns false for missing")
 
 print("inventory spec passed")

--- a/src/client/InventoryUI.luau
+++ b/src/client/InventoryUI.luau
@@ -20,6 +20,7 @@ local nextCursor
 local items = {}
 local cells = {}
 local cellPool = {}
+local gridContainer
 
 local function createCell()
     local frame = Instance.new("ImageButton")
@@ -28,37 +29,43 @@ local function createCell()
     frame.BorderSizePixel = 0
     local stroke = Instance.new("UIStroke")
     stroke.Parent = frame
+    frame.MouseButton1Click:Connect(function()
+        local uid = frame:GetAttribute("uid")
+        if not uid then
+            return
+        end
+        local result = RF_Equip:InvokeServer(uid)
+        if result and result.ok then
+            -- preview stub
+        end
+    end)
     return frame
 end
 
-local function getCell(index)
-    if cellPool[index] then
-        return cellPool[index]
+local function getCell()
+    local cell = table.remove(cellPool)
+    if cell then
+        return cell
     end
-    local cell = createCell()
-    cellPool[index] = cell
-    return cell
+    return createCell()
 end
 
-local function clearCells(grid)
+local function clearCells()
     for _, cell in pairs(cells) do
         cell.Parent = nil
+        cell:SetAttribute("uid", nil)
+        table.insert(cellPool, cell)
     end
     table.clear(cells)
 end
 
-local function renderGrid(grid)
-    clearCells(grid)
-    for i, item in ipairs(items) do
-        local cell = getCell(i)
+local function renderGrid()
+    clearCells()
+    for _, item in ipairs(items) do
+        local cell = getCell()
         cell.Image = item.icon
-        cell.Parent = grid
-        cell.MouseButton1Click:Connect(function()
-            local result = RF_Equip:InvokeServer(item.uid)
-            if result and result.ok then
-                -- preview stub
-            end
-        end)
+        cell:SetAttribute("uid", item.uid)
+        cell.Parent = gridContainer
         table.insert(cells, cell)
     end
 end
@@ -75,9 +82,9 @@ local function fetchPage(reset)
     nextCursor = newCursor
 end
 
-local function refresh(grid)
+local function refresh()
     fetchPage(true)
-    renderGrid(grid)
+    renderGrid()
 end
 
 function InventoryUI.Init()
@@ -108,7 +115,7 @@ function InventoryUI.Init()
         button.BackgroundColor3 = cat.color
         button.MouseButton1Click:Connect(function()
             currentCategory = cat.id
-            refresh(grid)
+            refresh()
         end)
         button.Parent = categoriesColumn
     end
@@ -132,12 +139,20 @@ function InventoryUI.Init()
     grid.Size = UDim2.new(1, -InventoryConfig.UI.GridPaddingPx * 2, 1, -40)
     grid.BackgroundTransparency = 1
     grid.CanvasSize = UDim2.new()
+    grid.AutomaticCanvasSize = Enum.AutomaticSize.Y
     grid.Parent = listPanel
+
+    gridContainer = Instance.new("Frame")
+    gridContainer.Name = "Container"
+    gridContainer.BackgroundTransparency = 1
+    gridContainer.Size = UDim2.new(1, 0, 0, 0)
+    gridContainer.AutomaticSize = Enum.AutomaticSize.Y
+    gridContainer.Parent = grid
 
     local gridLayout = Instance.new("UIGridLayout")
     gridLayout.CellSize = UDim2.new(0, InventoryConfig.UI.GridCellMinPx, 0, InventoryConfig.UI.GridCellMinPx)
     gridLayout.CellPadding = UDim2.new(0, InventoryConfig.UI.GridPaddingPx, 0, InventoryConfig.UI.GridPaddingPx)
-    gridLayout.Parent = grid
+    gridLayout.Parent = gridContainer
 
     local lastText
     search:GetPropertyChangedSignal("Text"):Connect(function()
@@ -148,12 +163,12 @@ function InventoryUI.Init()
         task.delay(debounceMs / 1000, function()
             if search.Text == lastText then
                 currentSearch = search.Text
-                refresh(grid)
+                refresh()
             end
         end)
     end)
 
-    refresh(grid)
+    refresh()
 end
 
 return InventoryUI

--- a/src/server/InventoryBridge.luau
+++ b/src/server/InventoryBridge.luau
@@ -21,6 +21,8 @@ local PAGE_SIZE = InventoryConfig.UI.PageSize or 40
 
 local SAMPLE_ITEMS = {}
 
+local PLAYER_ITEMS = {}
+
 for _, category in ipairs(InventoryConfig.Categories) do
     SAMPLE_ITEMS[category.id] = {}
     for i = 1, PAGE_SIZE * 2 do
@@ -39,6 +41,15 @@ end
 
 local InventoryBridge = {}
 
+local function getPlayerInventory(player)
+    local inv = PLAYER_ITEMS[player]
+    if not inv then
+        inv = {}
+        PLAYER_ITEMS[player] = inv
+    end
+    return inv
+end
+
 function InventoryBridge.GetDerivedAetherModifiers(player)
     return {
         target_add = 0,
@@ -56,8 +67,9 @@ end
 
 -- Inventory façade -----------------------------------------------------
 
-local function findItem(uidOrId)
-    for _, items in pairs(SAMPLE_ITEMS) do
+local function findPlayerItem(player, uidOrId)
+    local inventory = getPlayerInventory(player)
+    for _, items in pairs(inventory) do
         for _, item in ipairs(items) do
             if item.uid == uidOrId or item.id == uidOrId then
                 return item
@@ -67,7 +79,8 @@ local function findItem(uidOrId)
 end
 
 function InventoryBridge.GetPage(player, category, search, cursor)
-    local items = SAMPLE_ITEMS[category] or {}
+    local inventory = getPlayerInventory(player)
+    local items = inventory[category] or {}
     local filtered = {}
     local query = search and string.lower(search) or nil
     for _, item in ipairs(items) do
@@ -91,7 +104,22 @@ function InventoryBridge.GetPage(player, category, search, cursor)
 end
 
 function InventoryBridge.Equip(player, uidOrId)
-    return findItem(uidOrId) ~= nil
+    return findPlayerItem(player, uidOrId) ~= nil
+end
+
+function InventoryBridge._giveSampleItem(player, category, index)
+    local catItems = SAMPLE_ITEMS[category]
+    if not catItems then
+        return nil
+    end
+    local item = catItems[index]
+    if not item then
+        return nil
+    end
+    local inventory = getPlayerInventory(player)
+    inventory[category] = inventory[category] or {}
+    table.insert(inventory[category], item)
+    return item
 end
 
 function InventoryBridge.Use(player, uidOrId)


### PR DESCRIPTION
## Summary
- Only return items actually owned by the player in `InventoryBridge.GetPage`
- Pool and reuse inventory UI cells within a single container frame
- Update inventory spec for empty inventories and new items

## Testing
- ⚠️ `lua spec/inventory_spec.lua` *(Lua interpreter not available)*
- ⚠️ `lua spec/economy_spec.lua` *(Lua interpreter not available)*

------
https://chatgpt.com/codex/tasks/task_e_689dbac7fd8083278500c0ca9f01319a