### PR TITLE
Use ReplicatedStorage for shared config lookup

### DIFF
--- a/src/server/BurstService.luau
+++ b/src/server/BurstService.luau
@@ -2,22 +2,18 @@ local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
 local InventoryService = require(script.Parent:WaitForChild("InventoryService"))
 local Aether = require(script.Parent:WaitForChild("Aether"))
 
-local function loadItemsConfig()
-    if script and script.Parent and script.Parent.Parent then
-        local shared = script.Parent.Parent:FindFirstChild("shared")
-        if shared then
-            local ok, cfg = pcall(function()
-                return require(shared:WaitForChild("ItemsConfig"))
-            end)
-            if ok then
-                return cfg
-            end
-        end
+local function loadShared(name)
+    local ok, ReplicatedStorage = pcall(function()
+        return game:GetService("ReplicatedStorage")
+    end)
+    if ok and ReplicatedStorage then
+        local Shared = ReplicatedStorage:WaitForChild("Shared")
+        return require(Shared:WaitForChild(name))
     end
-    return require("ItemsConfig")
+    return require(name)
 end
 
-local ItemsConfig = loadItemsConfig()
+local ItemsConfig = loadShared("ItemsConfig")
 
 local BurstService = {}
 

--- a/src/server/InventoryService.luau
+++ b/src/server/InventoryService.luau
@@ -1,21 +1,17 @@
 local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
 
-local function loadConfig()
-    if script and script.Parent and script.Parent.Parent then
-        local shared = script.Parent.Parent:FindFirstChild("shared")
-        if shared then
-            local ok, cfg = pcall(function()
-                return require(shared:WaitForChild("ItemsConfig"))
-            end)
-            if ok then
-                return cfg
-            end
-        end
+local function loadShared(name)
+    local ok, ReplicatedStorage = pcall(function()
+        return game:GetService("ReplicatedStorage")
+    end)
+    if ok and ReplicatedStorage then
+        local Shared = ReplicatedStorage:WaitForChild("Shared")
+        return require(Shared:WaitForChild(name))
     end
-    return require("ItemsConfig")
+    return require(name)
 end
 
-local ItemsConfig = loadConfig()
+local ItemsConfig = loadShared("ItemsConfig")
 
 local InventoryService = {}
 

--- a/src/server/PlacementService.luau
+++ b/src/server/PlacementService.luau
@@ -3,16 +3,12 @@ local InventoryService = require(script.Parent:WaitForChild("InventoryService"))
 local Aether = require(script.Parent:WaitForChild("Aether"))
 
 local function loadShared(name)
-    if script and script.Parent and script.Parent.Parent then
-        local shared = script.Parent.Parent:FindFirstChild("shared")
-        if shared then
-            local ok, mod = pcall(function()
-                return require(shared:WaitForChild(name))
-            end)
-            if ok then
-                return mod
-            end
-        end
+    local ok, ReplicatedStorage = pcall(function()
+        return game:GetService("ReplicatedStorage")
+    end)
+    if ok and ReplicatedStorage then
+        local Shared = ReplicatedStorage:WaitForChild("Shared")
+        return require(Shared:WaitForChild(name))
     end
     return require(name)
 end
@@ -52,7 +48,7 @@ function PlacementService.Place(player, typeId, plotId, worldCFrame)
     local record = {
         typeId = typeId,
         plotId = plotId,
-        local = toLocal(worldCFrame),
+        ["local"] = toLocal(worldCFrame),
         active = true,
     }
     data.placed[uid] = record

--- a/src/server/PlayerManager.luau
+++ b/src/server/PlayerManager.luau
@@ -22,22 +22,18 @@ end
 local PlayerManager = {}
 local playerData = {}
 
-local function loadItemsConfig()
-    if script and script.Parent and script.Parent.Parent then
-        local shared = script.Parent.Parent:FindFirstChild("shared")
-        if shared then
-            local ok, cfg = pcall(function()
-                return require(shared:WaitForChild("ItemsConfig"))
-            end)
-            if ok then
-                return cfg
-            end
-        end
+local function loadShared(name)
+    local ok, ReplicatedStorage = pcall(function()
+        return game:GetService("ReplicatedStorage")
+    end)
+    if ok and ReplicatedStorage then
+        local Shared = ReplicatedStorage:WaitForChild("Shared")
+        return require(Shared:WaitForChild(name))
     end
-    return require("ItemsConfig")
+    return require(name)
 end
 
-local ItemsConfig = loadItemsConfig()
+local ItemsConfig = loadShared("ItemsConfig")
 
 local function createNewPlayerData(player)
     return {


### PR DESCRIPTION
## Summary
- Load shared modules via ReplicatedStorage with test-friendly fallback
- Remove direct `require("ItemsConfig")` calls
- Quote `local` key in placement records to fix syntax error

## Testing
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_689ddc05a36083278f5bc6bd52ce1514