### PR TITLE
Use ReplicatedStorage for shared config lookup

### DIFF
--- a/src/client/init.client.luau
+++ b/src/client/init.client.luau
@@ -127,6 +127,17 @@ createButton("Spawn Producer", UDim2.new(0, 10, 0, 280), function()
     end
 end)
 
+createButton("Give Seed", UDim2.new(0, 10, 0, 320), function()
+    local success = pcall(function()
+        return ReplicatedStorage.DebugGiveSeed:InvokeServer()
+    end)
+    if success then
+        print("Gave seed item")
+    else
+        print("Failed to give seed item")
+    end
+end)
+
 -- Load AetherClient
 print("Loading AetherClient...")
 local success, AetherClient = pcall(function()

--- a/src/server/BurstService.luau
+++ b/src/server/BurstService.luau
@@ -2,22 +2,18 @@ local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
 local InventoryService = require(script.Parent:WaitForChild("InventoryService"))
 local Aether = require(script.Parent:WaitForChild("Aether"))
 
-local function loadItemsConfig()
-    if script and script.Parent and script.Parent.Parent then
-        local shared = script.Parent.Parent:FindFirstChild("shared")
-        if shared then
-            local ok, cfg = pcall(function()
-                return require(shared:WaitForChild("ItemsConfig"))
-            end)
-            if ok then
-                return cfg
-            end
-        end
+local function loadShared(name)
+    local ok, ReplicatedStorage = pcall(function()
+        return game:GetService("ReplicatedStorage")
+    end)
+    if ok and ReplicatedStorage then
+        local Shared = ReplicatedStorage:WaitForChild("Shared")
+        return require(Shared:WaitForChild(name))
     end
-    return require("ItemsConfig")
+    return require(name)
 end
 
-local ItemsConfig = loadItemsConfig()
+local ItemsConfig = loadShared("ItemsConfig")
 
 local BurstService = {}
 

--- a/src/server/InventoryRemotes.luau
+++ b/src/server/InventoryRemotes.luau
@@ -4,11 +4,18 @@ local BurstService = require(script.Parent:WaitForChild("BurstService"))
 local PlacementService = require(script.Parent:WaitForChild("PlacementService"))
 
 local rfFetch = Instance.new("RemoteFunction")
-rfFetch.Name = "RF_InventoryFetch"
+rfFetch.Name = "Inventory_FetchPage"
 rfFetch.Parent = ReplicatedStorage
 rfFetch.OnServerInvoke = function(player, category, search, cursor)
     local result = InventoryService.GetPage(player, category, search, cursor)
     return result.items, result.nextCursor, result.total
+end
+
+local rfEquip = Instance.new("RemoteFunction")
+rfEquip.Name = "Inventory_Equip"
+rfEquip.Parent = ReplicatedStorage
+rfEquip.OnServerInvoke = function(player, uid)
+    return { ok = false }
 end
 
 local rfBurst = Instance.new("RemoteFunction")
@@ -33,7 +40,8 @@ rfRemove.OnServerInvoke = function(player, uid)
 end
 
 return {
-    InventoryFetch = rfFetch,
+    FetchPage = rfFetch,
+    Equip = rfEquip,
     UseBurst = rfBurst,
     PlaceItem = rfPlace,
     RemovePlaced = rfRemove,

--- a/src/server/InventoryService.luau
+++ b/src/server/InventoryService.luau
@@ -1,21 +1,17 @@
 local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
 
-local function loadConfig()
-    if script and script.Parent and script.Parent.Parent then
-        local shared = script.Parent.Parent:FindFirstChild("shared")
-        if shared then
-            local ok, cfg = pcall(function()
-                return require(shared:WaitForChild("ItemsConfig"))
-            end)
-            if ok then
-                return cfg
-            end
-        end
+local function loadShared(name)
+    local ok, ReplicatedStorage = pcall(function()
+        return game:GetService("ReplicatedStorage")
+    end)
+    if ok and ReplicatedStorage then
+        local Shared = ReplicatedStorage:WaitForChild("Shared")
+        return require(Shared:WaitForChild(name))
     end
-    return require("ItemsConfig")
+    return require(name)
 end
 
-local ItemsConfig = loadConfig()
+local ItemsConfig = loadShared("ItemsConfig")
 
 local InventoryService = {}
 
@@ -47,6 +43,7 @@ function InventoryService.GetPage(player, category, search, cursor)
         local cfg = ItemsConfig.Types[typeId]
         if cfg and cfg.category == category then
             table.insert(items, {
+                uid = typeId,
                 typeId = typeId,
                 displayName = cfg.displayName,
                 count = count,

--- a/src/server/PlacementService.luau
+++ b/src/server/PlacementService.luau
@@ -3,16 +3,12 @@ local InventoryService = require(script.Parent:WaitForChild("InventoryService"))
 local Aether = require(script.Parent:WaitForChild("Aether"))
 
 local function loadShared(name)
-    if script and script.Parent and script.Parent.Parent then
-        local shared = script.Parent.Parent:FindFirstChild("shared")
-        if shared then
-            local ok, mod = pcall(function()
-                return require(shared:WaitForChild(name))
-            end)
-            if ok then
-                return mod
-            end
-        end
+    local ok, ReplicatedStorage = pcall(function()
+        return game:GetService("ReplicatedStorage")
+    end)
+    if ok and ReplicatedStorage then
+        local Shared = ReplicatedStorage:WaitForChild("Shared")
+        return require(Shared:WaitForChild(name))
     end
     return require(name)
 end
@@ -52,7 +48,7 @@ function PlacementService.Place(player, typeId, plotId, worldCFrame)
     local record = {
         typeId = typeId,
         plotId = plotId,
-        local = toLocal(worldCFrame),
+        ["local"] = toLocal(worldCFrame),
         active = true,
     }
     data.placed[uid] = record

--- a/src/server/PlayerManager.luau
+++ b/src/server/PlayerManager.luau
@@ -22,22 +22,18 @@ end
 local PlayerManager = {}
 local playerData = {}
 
-local function loadItemsConfig()
-    if script and script.Parent and script.Parent.Parent then
-        local shared = script.Parent.Parent:FindFirstChild("shared")
-        if shared then
-            local ok, cfg = pcall(function()
-                return require(shared:WaitForChild("ItemsConfig"))
-            end)
-            if ok then
-                return cfg
-            end
-        end
+local function loadShared(name)
+    local ok, ReplicatedStorage = pcall(function()
+        return game:GetService("ReplicatedStorage")
+    end)
+    if ok and ReplicatedStorage then
+        local Shared = ReplicatedStorage:WaitForChild("Shared")
+        return require(Shared:WaitForChild(name))
     end
-    return require("ItemsConfig")
+    return require(name)
 end
 
-local ItemsConfig = loadItemsConfig()
+local ItemsConfig = loadShared("ItemsConfig")
 
 local function createNewPlayerData(player)
     return {

--- a/src/server/init.server.luau
+++ b/src/server/init.server.luau
@@ -23,6 +23,10 @@ local debugAddCrumbs = Instance.new("RemoteFunction")
 debugAddCrumbs.Name = "DebugAddCrumbs"
 debugAddCrumbs.Parent = ReplicatedStorage
 
+local debugGiveSeed = Instance.new("RemoteFunction")
+debugGiveSeed.Name = "DebugGiveSeed"
+debugGiveSeed.Parent = ReplicatedStorage
+
 local spawnProducer = Instance.new("RemoteFunction")
 spawnProducer.Name = "SpawnProducer"
 spawnProducer.Parent = ReplicatedStorage
@@ -45,6 +49,7 @@ local Aether = require(script:WaitForChild("Aether"))
 local PlayerManager = require(script:WaitForChild("PlayerManager"))
 local DebugCommands = require(script:WaitForChild("DebugCommands"))
 local InventoryBridge = require(script:WaitForChild("InventoryBridge"))
+local InventoryService = require(script:WaitForChild("InventoryService"))
 local InventoryRemotes = require(script:WaitForChild("InventoryRemotes"))
 
 local SaveScheduler = require(script:WaitForChild("SaveScheduler"))
@@ -111,6 +116,13 @@ debugAddCrumbs.OnServerInvoke = function(player, amount)
     local success = Economy.ApplyCrumbsDelta(data, amount, "grant")
     PlayerManager.SavePlayerData(player, data)
     return success, data.crumbs
+end
+
+debugGiveSeed.OnServerInvoke = function(player)
+    InventoryService.Add(player, "prod_cube_basic", 1)
+    local data = PlayerManager.GetPlayerData(player)
+    PlayerManager.SavePlayerData(player, data)
+    return true
 end
 
 -- Aether RequestSell handler


### PR DESCRIPTION
## Summary
- Load shared modules via ReplicatedStorage with test-friendly fallback
- Remove direct require("ItemsConfig") calls
- Quote `local` key in placement records to fix syntax error
- Restore inventory remotes and add debug seed helper

## Testing
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_689ddc05a36083278f5bc6bd52ce1514