### PR TITLE
feat: add item hold and placement workflow

### DIFF
--- a/src/client/HeldItemController.luau
+++ b/src/client/HeldItemController.luau
@@ -1,0 +1,134 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local UserInputService = game:GetService("UserInputService")
+
+local StartHolding = ReplicatedStorage:WaitForChild("StartHoldingItem")
+local RequestPlace = ReplicatedStorage:WaitForChild("RequestPlaceItem")
+local ConfirmPlacement = ReplicatedStorage:WaitForChild("ConfirmPlacement")
+local PlacementRejected = ReplicatedStorage:WaitForChild("PlacementRejected")
+
+local ItemsConfig = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("ItemsConfig"))
+
+local player = Players.LocalPlayer
+local mouse = player:GetMouse()
+
+local HeldItemController = {}
+
+local currentHeld
+local heldModel
+local ghostModel
+local handsUpAnim
+
+local plotBounds = {
+    min = Vector3.new(-50, 0, -50),
+    max = Vector3.new(50, 0, 50),
+}
+
+local function insideBounds(pos)
+    return pos.X >= plotBounds.min.X and pos.X <= plotBounds.max.X and pos.Z >= plotBounds.min.Z and pos.Z <= plotBounds.max.Z
+end
+
+local function stopHolding()
+    if heldModel then
+        heldModel:Destroy()
+        heldModel = nil
+    end
+    if handsUpAnim then
+        handsUpAnim:Stop()
+        handsUpAnim = nil
+    end
+    currentHeld = nil
+end
+
+function HeldItemController.startHold(item)
+    if currentHeld then
+        return
+    end
+    currentHeld = item
+    StartHolding:FireServer(item.uid)
+
+    local cfg = ItemsConfig.Types[item.typeId]
+    if not cfg then
+        return
+    end
+
+    local model = ReplicatedStorage:WaitForChild("Assets"):WaitForChild("Models"):WaitForChild(cfg.model):Clone()
+    local character = player.Character or player.CharacterAdded:Wait()
+    local hrp = character:WaitForChild("HumanoidRootPart")
+    local attach = hrp:FindFirstChild("HeldItemAttachment")
+    if not attach then
+        attach = Instance.new("Attachment")
+        attach.Name = "HeldItemAttachment"
+        attach.Position = Vector3.new(0, 5, 0)
+        attach.Parent = hrp
+    end
+    model.Parent = attach
+    heldModel = model
+
+    local humanoid = character:WaitForChild("Humanoid")
+    local anim = Instance.new("Animation")
+    anim.AnimationId = "rbxassetid://0"
+    handsUpAnim = humanoid:LoadAnimation(anim)
+    handsUpAnim:Play()
+end
+
+local function spawnGhost(position, cfg)
+    if ghostModel then
+        ghostModel:Destroy()
+    end
+    ghostModel = ReplicatedStorage:WaitForChild("Assets"):WaitForChild("Models"):WaitForChild(cfg.model):Clone()
+    for _, part in ipairs(ghostModel:GetDescendants()) do
+        if part:IsA("BasePart") then
+            part.Transparency = 0.5
+            part.CanCollide = false
+        end
+    end
+    ghostModel.CFrame = CFrame.new(position)
+    ghostModel.Parent = workspace
+end
+
+function HeldItemController.tryPlace(position)
+    if not currentHeld then
+        return
+    end
+    if not insideBounds(position) then
+        return
+    end
+    local cfg = ItemsConfig.Types[currentHeld.typeId]
+    if not cfg then
+        return
+    end
+    spawnGhost(position, cfg)
+    RequestPlace:FireServer(currentHeld.uid, position)
+end
+
+ConfirmPlacement.OnClientEvent:Connect(function()
+    if ghostModel then
+        ghostModel:Destroy()
+        ghostModel = nil
+    end
+    stopHolding()
+end)
+
+PlacementRejected.OnClientEvent:Connect(function()
+    if ghostModel then
+        ghostModel:Destroy()
+        ghostModel = nil
+    end
+end)
+
+UserInputService.InputBegan:Connect(function(input, gpe)
+    if gpe then
+        return
+    end
+    if input.UserInputType == Enum.UserInputType.MouseButton1 and currentHeld then
+        HeldItemController.tryPlace(mouse.Hit.Position)
+    end
+end)
+
+function HeldItemController.isHolding()
+    return currentHeld ~= nil
+end
+
+return HeldItemController
+

--- a/src/client/InventoryUI.luau
+++ b/src/client/InventoryUI.luau
@@ -4,9 +4,9 @@ local RunService = game:GetService("RunService")
 local TweenService = game:GetService("TweenService")
 
 local InventoryConfig = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("InventoryConfig"))
+local HeldItemController = require(script.Parent:WaitForChild("HeldItemController"))
 
 local RF_Fetch = ReplicatedStorage:WaitForChild("Inventory_FetchPage")
-local RF_Equip = ReplicatedStorage:WaitForChild("Inventory_Equip")
 
 local localPlayer = Players.LocalPlayer
 
@@ -19,6 +19,7 @@ local currentCategory = InventoryConfig.Categories[1].id
 local currentSearch = ""
 local nextCursor
 local items = {}
+local itemLookup = {}
 local cells = {}
 local cellPool = {}
 local gridContainer
@@ -35,9 +36,9 @@ local function createCell()
         if not uid then
             return
         end
-        local result = RF_Equip:InvokeServer(uid)
-        if result and result.ok then
-            -- preview stub
+        local item = itemLookup[uid]
+        if item then
+            HeldItemController.startHold(item)
         end
     end)
     return frame
@@ -75,10 +76,12 @@ local function fetchPage(reset)
     if reset then
         nextCursor = nil
         items = {}
+        itemLookup = {}
     end
     local page, newCursor = RF_Fetch:InvokeServer(currentCategory, currentSearch, nextCursor)
     for _, item in ipairs(page) do
         table.insert(items, item)
+        itemLookup[item.uid] = item
     end
     nextCursor = newCursor
 end

--- a/src/server/InventoryRemotes.luau
+++ b/src/server/InventoryRemotes.luau
@@ -2,6 +2,10 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local InventoryService = require(script.Parent:WaitForChild("InventoryService"))
 local BurstService = require(script.Parent:WaitForChild("BurstService"))
 local PlacementService = require(script.Parent:WaitForChild("PlacementService"))
+local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
+
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+local ItemsConfig = require(Shared:WaitForChild("ItemsConfig"))
 
 local rfFetch = Instance.new("RemoteFunction")
 rfFetch.Name = "Inventory_FetchPage"
@@ -39,11 +43,57 @@ rfRemove.OnServerInvoke = function(player, uid)
     return PlacementService.Remove(player, uid)
 end
 
+local evStartHolding = Instance.new("RemoteEvent")
+evStartHolding.Name = "StartHoldingItem"
+evStartHolding.Parent = ReplicatedStorage
+evStartHolding.OnServerEvent = function(player, uid)
+    local data = PlayerManager.GetPlayerData(player)
+    data.heldItem = uid
+end
+
+local evRequestPlace = Instance.new("RemoteEvent")
+evRequestPlace.Name = "RequestPlaceItem"
+evRequestPlace.Parent = ReplicatedStorage
+
+local evConfirm = Instance.new("RemoteEvent")
+evConfirm.Name = "ConfirmPlacement"
+evConfirm.Parent = ReplicatedStorage
+
+local evReject = Instance.new("RemoteEvent")
+evReject.Name = "PlacementRejected"
+evReject.Parent = ReplicatedStorage
+
+evRequestPlace.OnServerEvent = function(player, uid, position)
+    local data = PlayerManager.GetPlayerData(player)
+    if data.heldItem ~= uid then
+        evReject:FireClient(player)
+        return
+    end
+    local cfg = ItemsConfig.Types[uid]
+    if not cfg then
+        evReject:FireClient(player)
+        return
+    end
+    if not InventoryService.Consume(player, uid, 1) then
+        evReject:FireClient(player)
+        return
+    end
+    local model = ReplicatedStorage:WaitForChild("Assets"):WaitForChild("Models"):WaitForChild(cfg.model):Clone()
+    model.CFrame = CFrame.new(position)
+    model.Parent = workspace
+    data.heldItem = nil
+    evConfirm:FireClient(player, model)
+end
+
 return {
     FetchPage = rfFetch,
     Equip = rfEquip,
     UseBurst = rfBurst,
     PlaceItem = rfPlace,
     RemovePlaced = rfRemove,
+    StartHolding = evStartHolding,
+    RequestPlace = evRequestPlace,
+    ConfirmPlacement = evConfirm,
+    PlacementRejected = evReject,
 }
 

--- a/src/server/PlayerManager.luau
+++ b/src/server/PlayerManager.luau
@@ -53,6 +53,7 @@ local function createNewPlayerData(player)
         producers = {},
         placed = {},
         timestamps = {},
+        heldItem = nil,
     }
 end
 
@@ -76,6 +77,7 @@ local function migrate(data)
     data.producers = data.producers or {}
     data.placed = data.placed or {}
     data.timestamps = data.timestamps or {}
+    data.heldItem = data.heldItem
     return data
 end
 


### PR DESCRIPTION
## Summary
- support holding inventory items locally with animation and ghost placement
- add server events for item hold start and placement validation
- track current held item on player data

## Testing
- `lua spec/economy_spec.lua`
- `rojo build -o "skyhunters.rbxlx"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de984f89c8327b31743792a02bd6d