### PR TITLE
Handle missing asset models gracefully

### DIFF
--- a/src/client/HeldItemController.luau
+++ b/src/client/HeldItemController.luau
@@ -19,6 +19,37 @@ local heldModel
 local ghostModel
 local handsUpAnim
 
+local function getModel(modelName)
+    local assets = ReplicatedStorage:FindFirstChild("Assets")
+    if not assets then
+        warn("[HeldItemController] Assets folder missing")
+        local p = Instance.new("Part")
+        p.Name = modelName
+        p.Size = Vector3.new(1, 1, 1)
+        p.Anchored = true
+        return p
+    end
+    local models = assets:FindFirstChild("Models")
+    if not models then
+        warn("[HeldItemController] Models folder missing in Assets")
+        local p = Instance.new("Part")
+        p.Name = modelName
+        p.Size = Vector3.new(1, 1, 1)
+        p.Anchored = true
+        return p
+    end
+    local model = models:FindFirstChild(modelName)
+    if not model then
+        warn("[HeldItemController] Model " .. modelName .. " missing")
+        local p = Instance.new("Part")
+        p.Name = modelName
+        p.Size = Vector3.new(1, 1, 1)
+        p.Anchored = true
+        return p
+    end
+    return model:Clone()
+end
+
 local plotBounds = {
     min = Vector3.new(-50, 0, -50),
     max = Vector3.new(50, 0, 50),
@@ -52,7 +83,7 @@ function HeldItemController.startHold(item)
         return
     end
 
-    local model = ReplicatedStorage:WaitForChild("Assets"):WaitForChild("Models"):WaitForChild(cfg.model):Clone()
+    local model = getModel(cfg.model)
     local character = player.Character or player.CharacterAdded:Wait()
     local hrp = character:WaitForChild("HumanoidRootPart")
     local attach = hrp:FindFirstChild("HeldItemAttachment")
@@ -76,11 +107,16 @@ local function spawnGhost(position, cfg)
     if ghostModel then
         ghostModel:Destroy()
     end
-    ghostModel = ReplicatedStorage:WaitForChild("Assets"):WaitForChild("Models"):WaitForChild(cfg.model):Clone()
-    for _, part in ipairs(ghostModel:GetDescendants()) do
-        if part:IsA("BasePart") then
-            part.Transparency = 0.5
-            part.CanCollide = false
+    ghostModel = getModel(cfg.model)
+    if ghostModel:IsA("BasePart") then
+        ghostModel.Transparency = 0.5
+        ghostModel.CanCollide = false
+    else
+        for _, part in ipairs(ghostModel:GetDescendants()) do
+            if part:IsA("BasePart") then
+                part.Transparency = 0.5
+                part.CanCollide = false
+            end
         end
     end
     ghostModel.CFrame = CFrame.new(position)

--- a/src/client/PlacedRenderer.luau
+++ b/src/client/PlacedRenderer.luau
@@ -5,6 +5,37 @@ local ItemsConfig = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChil
 
 local PlacedRenderer = {}
 
+local function getModel(modelName)
+    local assets = ReplicatedStorage:FindFirstChild("Assets")
+    if not assets then
+        warn("[PlacedRenderer] Assets folder missing")
+        local p = Instance.new("Part")
+        p.Name = modelName
+        p.Size = Vector3.new(1, 1, 1)
+        p.Anchored = true
+        return p
+    end
+    local models = assets:FindFirstChild("Models")
+    if not models then
+        warn("[PlacedRenderer] Models folder missing in Assets")
+        local p = Instance.new("Part")
+        p.Name = modelName
+        p.Size = Vector3.new(1, 1, 1)
+        p.Anchored = true
+        return p
+    end
+    local model = models:FindFirstChild(modelName)
+    if not model then
+        warn("[PlacedRenderer] Model " .. modelName .. " missing")
+        local p = Instance.new("Part")
+        p.Name = modelName
+        p.Size = Vector3.new(1, 1, 1)
+        p.Anchored = true
+        return p
+    end
+    return model:Clone()
+end
+
 local function getFolder()
     local folder = workspace:FindFirstChild("ClientObjects")
     if not folder then
@@ -26,7 +57,7 @@ function PlacedRenderer.Render(params)
     if not cfg then
         return
     end
-    local model = ReplicatedStorage:WaitForChild("Assets"):WaitForChild("Models"):WaitForChild(cfg.model):Clone()
+    local model = getModel(cfg.model)
     model.CFrame = params.worldCFrame
     model.Parent = getFolder()
 end

--- a/src/server/InventoryRemotes.luau
+++ b/src/server/InventoryRemotes.luau
@@ -63,6 +63,37 @@ local evReject = Instance.new("RemoteEvent")
 evReject.Name = "PlacementRejected"
 evReject.Parent = ReplicatedStorage
 
+local function getModel(modelName)
+    local assets = ReplicatedStorage:FindFirstChild("Assets")
+    if not assets then
+        warn("[InventoryRemotes] Assets folder missing")
+        local p = Instance.new("Part")
+        p.Name = modelName
+        p.Size = Vector3.new(1, 1, 1)
+        p.Anchored = true
+        return p
+    end
+    local models = assets:FindFirstChild("Models")
+    if not models then
+        warn("[InventoryRemotes] Models folder missing in Assets")
+        local p = Instance.new("Part")
+        p.Name = modelName
+        p.Size = Vector3.new(1, 1, 1)
+        p.Anchored = true
+        return p
+    end
+    local model = models:FindFirstChild(modelName)
+    if not model then
+        warn("[InventoryRemotes] Model " .. modelName .. " missing")
+        local p = Instance.new("Part")
+        p.Name = modelName
+        p.Size = Vector3.new(1, 1, 1)
+        p.Anchored = true
+        return p
+    end
+    return model:Clone()
+end
+
 evRequestPlace.OnServerEvent = function(player, uid, position)
     local data = PlayerManager.GetPlayerData(player)
     if data.heldItem ~= uid then
@@ -78,7 +109,7 @@ evRequestPlace.OnServerEvent = function(player, uid, position)
         evReject:FireClient(player)
         return
     end
-    local model = ReplicatedStorage:WaitForChild("Assets"):WaitForChild("Models"):WaitForChild(cfg.model):Clone()
+    local model = getModel(cfg.model)
     model.CFrame = CFrame.new(position)
     model.Parent = workspace
     data.heldItem = nil


### PR DESCRIPTION
## Summary
- add helper to fetch asset models with fallbacks and warnings
- ensure client placement and held item controllers use new helper
- allow server placement to spawn placeholder models when assets absent

## Testing
- `lua spec/aether_spec.lua`
- `lua spec/economy_spec.lua`
- `lua spec/inventory_spec.lua`
- `lua spec/persistence_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_689def0bf6748327998aa2393b5cfd89