### PR TITLE
Enable free placement and persist producer placements

### DIFF
--- a/spec/aether_integration_spec.lua
+++ b/spec/aether_integration_spec.lua
@@ -1,0 +1,55 @@
+package.path = "src/server/?.luau;src/server/?/init.luau;src/shared/?.luau;src/shared/?/init.luau;" .. package.path
+
+if not time then
+    function time()
+        return os.clock()
+    end
+end
+
+if not Color3 then
+    Color3 = { fromRGB = function() return {} end }
+end
+
+if not CFrame then
+    CFrame = {}
+    function CFrame.new(x, y, z)
+        return {
+            Position = { X = x, Y = y, Z = z },
+            ToOrientation = function()
+                return 0, 0, 0
+            end,
+        }
+    end
+end
+
+game = {
+    GetService = function(self, name)
+        if name == "Players" then
+            return { PlayerRemoving = { Connect = function() end } }
+        else
+            error("service not available")
+        end
+    end
+}
+
+script = {
+    Parent = {
+        WaitForChild = function(_, name)
+            return name
+        end,
+    },
+}
+
+local PlayerManager = require("PlayerManager")
+local InventoryService = require("InventoryService")
+local PlacementService = require("PlacementService")
+
+local player = { UserId = 1, Name = "Tester" }
+local data = PlayerManager.GetPlayerData(player)
+InventoryService.Add(player, "prod_cube_basic", 1)
+
+local result = PlacementService.Place(player, "prod_cube_basic", nil, CFrame.new(0,0,0))
+assert(result.ok, "placement should succeed")
+assert(data.aether.totalRate > 0, "producer increases totalRate")
+
+print("aether integration spec passed")

--- a/src/client/HeldItemController.luau
+++ b/src/client/HeldItemController.luau
@@ -22,7 +22,25 @@ local currentTemplate: Instance? = nil
 local lastMouseHit: CFrame? = nil
 
 local GRID = 1
+local snapEnabled = false
 local currentYaw = 0
+local lastPlace = 0
+
+local exitButton
+do
+    local gui = Instance.new("ScreenGui")
+    gui.Name = "PlacementGui"
+    gui.ResetOnSpawn = false
+    gui.Parent = player:WaitForChild("PlayerGui")
+
+    exitButton = Instance.new("TextButton")
+    exitButton.Text = "×"
+    exitButton.Size = UDim2.new(0, 24, 0, 24)
+    exitButton.Position = UDim2.new(1, -28, 0, 4)
+    exitButton.AnchorPoint = Vector2.new(1, 0)
+    exitButton.Visible = false
+    exitButton.Parent = gui
+end
 
 local function getModel(modelName: string): Instance
     local assets = ReplicatedStorage:FindFirstChild("Assets")
@@ -99,6 +117,9 @@ local function spawnGhost(asset: Instance): Instance
             i.CanCollide = false
             i.CanQuery = false
             i.CanTouch = false
+            i.Anchored = true
+        elseif i:IsA("Weld") or i:IsA("WeldConstraint") or i:IsA("Motor6D") or i:IsA("BallSocketConstraint") then
+            i:Destroy()
         end
     end
     if g:IsA("Model") then
@@ -122,8 +143,14 @@ local function updateGhostAt(mouseHit: CFrame)
         return
     end
     local pos = mouseHit.Position
-    local snapped = Vector3.new(snap(pos.X, GRID), snap(pos.Y, GRID), snap(pos.Z, GRID))
-    local cf = CFrame.new(snapped) * CFrame.Angles(0, currentYaw, 0)
+    local useSnap = snapEnabled and GRID > 0 and not (UserInputService:IsKeyDown(Enum.KeyCode.LeftShift) or UserInputService:IsKeyDown(Enum.KeyCode.RightShift))
+    local basePos
+    if useSnap then
+        basePos = Vector3.new(snap(pos.X, GRID), snap(pos.Y, GRID), snap(pos.Z, GRID))
+    else
+        basePos = pos
+    end
+    local cf = CFrame.new(basePos) * CFrame.Angles(0, currentYaw, 0)
     pivotTo(cf, ghostModel)
 end
 
@@ -167,7 +194,12 @@ local function cancelPlacement()
         ghostModel:Destroy()
         ghostModel = nil
     end
+    exitButton.Visible = false
 end
+
+exitButton.Activated:Connect(function()
+    cancelPlacement()
+end)
 
 function HeldItemController.startHold(item)
     if placingItemId then
@@ -186,12 +218,18 @@ function HeldItemController.startHold(item)
     attachOverHead(character, currentTemplate)
     spawnGhost(currentTemplate)
     updateGhostAt(mouse.Hit)
+    exitButton.Visible = true
 end
 
 local function tryPlace()
     if not placingItemId or not ghostModel then
         return
     end
+    local now = tick()
+    if now - lastPlace < 0.2 then
+        return
+    end
+    lastPlace = now
     local cf
     if ghostModel:IsA("Model") then
         cf = ghostModel:GetPivot()
@@ -201,16 +239,22 @@ local function tryPlace()
     RequestPlace:FireServer(placingItemId, cf)
 end
 
-ConfirmPlacement.OnClientEvent:Connect(function(ok)
-    if ok then
-        placingCount -= 1
-        if placingCount <= 0 then
-            cancelPlacement()
-        end
+ConfirmPlacement.OnClientEvent:Connect(function(ok, payload)
+    if not ok then
+        return
     end
     if ghostModel then
         ghostModel:Destroy()
         ghostModel = nil
+    end
+    placingCount = payload and payload.remaining or 0
+    if placingCount > 0 then
+        spawnGhost(currentTemplate)
+        if lastMouseHit then
+            updateGhostAt(lastMouseHit)
+        end
+    else
+        cancelPlacement()
     end
 end)
 
@@ -242,12 +286,19 @@ UserInputService.InputBegan:Connect(function(input, processed)
     end
     if input.UserInputType == Enum.UserInputType.MouseButton1 then
         tryPlace()
+    elseif input.UserInputType == Enum.UserInputType.MouseButton2 then
+        cancelPlacement()
     elseif input.KeyCode == Enum.KeyCode.R then
         if UserInputService:IsKeyDown(Enum.KeyCode.LeftShift) or UserInputService:IsKeyDown(Enum.KeyCode.RightShift) then
             currentYaw += math.rad(90)
         else
             currentYaw += math.rad(15)
         end
+        if lastMouseHit then
+            updateGhostAt(lastMouseHit)
+        end
+    elseif input.KeyCode == Enum.KeyCode.G then
+        snapEnabled = not snapEnabled
         if lastMouseHit then
             updateGhostAt(lastMouseHit)
         end

--- a/src/server/InventoryRemotes.luau
+++ b/src/server/InventoryRemotes.luau
@@ -93,22 +93,25 @@ local function getModel(modelName)
     end
     return model:Clone()
 end
-evRequestPlace.OnServerEvent:Connect(function(player, uid, worldCFrame)
+evRequestPlace.OnServerEvent:Connect(function(player, typeId, worldCFrame)
     local data = PlayerManager.GetPlayerData(player)
-    if data.heldItem ~= uid then
+    if data.heldItem ~= typeId then
         evReject:FireClient(player)
         return
     end
-    local cfg = ItemsConfig.Types[uid]
-    if not cfg then
+    local result = PlacementService.Place(player, typeId, nil, worldCFrame)
+    if not result.ok then
         evReject:FireClient(player)
         return
     end
-    if not InventoryService.Consume(player, uid, 1) then
-        evReject:FireClient(player)
-        return
-    end
+    local cfg = ItemsConfig.Types[typeId]
     local model = getModel(cfg.model)
+    for _, p in ipairs(model:GetDescendants()) do
+        if p:IsA("BasePart") then
+            p.Anchored = true
+            p.CanCollide = true
+        end
+    end
     if model:IsA("BasePart") then
         model.CFrame = worldCFrame
     else
@@ -119,8 +122,11 @@ evRequestPlace.OnServerEvent:Connect(function(player, uid, worldCFrame)
         end
     end
     model.Parent = workspace
-    data.heldItem = nil
-    evConfirm:FireClient(player, true, model)
+    local remaining = data.inventory[typeId] or 0
+    if remaining <= 0 then
+        data.heldItem = nil
+    end
+    evConfirm:FireClient(player, true, { remaining = remaining, placedId = result.uid })
 end)
 
 return {

--- a/src/server/PlacementService.luau
+++ b/src/server/PlacementService.luau
@@ -45,15 +45,16 @@ function PlacementService.Place(player, typeId, plotId, worldCFrame)
     local data = PlayerManager.GetPlayerData(player)
     data.placed = data.placed or {}
     local uid = Uid.next("p")
+    local prodUid = Aether.AddProducer(data, typeId, cfg.rate)
     local record = {
-        typeId = typeId,
+        itemId = typeId,
         plotId = plotId,
-        ["local"] = toLocal(worldCFrame),
-        active = true,
+        cf = toLocal(worldCFrame),
+        kind = "producer",
+        rate = cfg.rate,
+        producerUid = prodUid,
     }
     data.placed[uid] = record
-    Aether.Settle(data)
-    data.aether.totalRate = (data.aether.totalRate or 0) + (cfg.rate or 0)
     return { ok = true, uid = uid, serverRecord = record }
 end
 
@@ -63,11 +64,11 @@ function PlacementService.Remove(player, uid)
     if not record then
         return { ok = false, err = "not_found" }
     end
-    local cfg = ItemsConfig.Types[record.typeId]
-    Aether.Settle(data)
-    data.aether.totalRate = (data.aether.totalRate or 0) - (cfg and cfg.rate or 0)
+    if record.producerUid then
+        Aether.RemoveProducer(data, record.producerUid)
+    end
     data.placed[uid] = nil
-    InventoryService.Add(player, record.typeId, 1)
+    InventoryService.Add(player, record.itemId or record.typeId, 1)
     return { ok = true }
 end
 

--- a/src/server/PlayerManager.luau
+++ b/src/server/PlayerManager.luau
@@ -100,14 +100,15 @@ function PlayerManager.GetPlayerData(player)
             Aether = require("Aether")
         end
         Aether.Init(data)
-        local total = 0
         for _, record in pairs(data.placed) do
-            local cfg = ItemsConfig.Types[record.typeId]
-            if cfg and (record.active ~= false) then
-                total = total + (cfg.rate or 0)
+            if record.kind == "producer" then
+                if not record.producerUid or not data.producers[record.producerUid] then
+                    local puid = Aether.AddProducer(data, record.itemId or record.typeId, record.rate)
+                    record.producerUid = puid
+                end
             end
         end
-        data.aether.totalRate = total
+        Aether.RebuildTotalRate(data)
         SaveScheduler.start(player.UserId, function()
             DataStoreAdapter.Save(player, data)
         end)


### PR DESCRIPTION
## Summary
- default placement to free mode with optional grid snapping toggled by **G** and shift bypass
- clean up ghost models and add X/right-click cancel with debounce
- persist placed producers on server and wire to Aether
- add Aether placement integration test

## Testing
- `lua spec/economy_spec.lua`
- `lua spec/aether_spec.lua`
- `lua spec/inventory_spec.lua`
- `lua spec/persistence_spec.lua`
- `lua spec/aether_integration_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_689eb9e30ac883279676b019b62eaddb