### PR TITLE
Improve placement persistence and ghost preview handling

### DIFF
--- a/spec/aether_integration_spec.lua
+++ b/spec/aether_integration_spec.lua
@@ -22,6 +22,13 @@ if not CFrame then
     end
 end
 
+if not Vector3 then
+    Vector3 = {}
+    function Vector3.new(x, y, z)
+        return { X = x, Y = y, Z = z }
+    end
+end
+
 game = {
     GetService = function(self, name)
         if name == "Players" then

--- a/spec/placement_persistence_spec.lua
+++ b/spec/placement_persistence_spec.lua
@@ -22,6 +22,13 @@ if not CFrame then
     end
 end
 
+if not Vector3 then
+    Vector3 = {}
+    function Vector3.new(x, y, z)
+        return { X = x, Y = y, Z = z }
+    end
+end
+
 game = {
     GetService = function(self, name)
         if name == "Players" then
@@ -57,6 +64,6 @@ local rec = loaded.placed[result.uid]
 assert(rec, "placement should persist")
 assert(rec.itemId == "prod_cube_basic", "itemId persisted")
 assert(rec.uid == result.uid, "uid stored in record")
-assert(rec.cf and ((rec.cf.px == 5) or (rec.cf.Position and rec.cf.Position.X == 5)), "position persisted")
+assert(rec.cf and math.abs((rec.cf.rx or 0) - 0.55) < 0.001, "position persisted")
 
 print("placement persistence spec passed")

--- a/src/client/HeldItemController.luau
+++ b/src/client/HeldItemController.luau
@@ -1,6 +1,7 @@
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserInputService = game:GetService("UserInputService")
+local RunService = game:GetService("RunService")
 
 local StartHolding = ReplicatedStorage:WaitForChild("StartHoldingItem")
 local RequestPlace = ReplicatedStorage:WaitForChild("RequestPlaceItem")
@@ -148,17 +149,18 @@ local function spawnGhost(asset: Instance): Instance
             i.CanQuery = false
             i.CanTouch = false
             i.Anchored = true
-        elseif i:IsA("Weld") or i:IsA("WeldConstraint") or i:IsA("Motor6D") or i:IsA("BallSocketConstraint") then
+        elseif i:IsA("Weld") or i:IsA("WeldConstraint") or i:IsA("Motor6D")
+            or i:IsA("BallSocketConstraint") or i:IsA("HingeConstraint")
+            or i:IsA("RodConstraint") then
             i:Destroy()
         end
     end
+    ghostify(g)
     if g:IsA("Model") then
         g:ScaleTo(1)
         for _, d in ipairs(g:GetDescendants()) do
             ghostify(d)
         end
-    elseif g:IsA("BasePart") then
-        ghostify(g)
     end
     ghostModel = g
     return g
@@ -203,14 +205,14 @@ local function attachOverHead(character: Model, asset: Instance)
         end
     end
 
-    local head = character:FindFirstChild("Head") or character:FindFirstChild("HumanoidRootPart")
+    local hrp = character:FindFirstChild("HumanoidRootPart")
     local base = (carry:IsA("Model") and (carry.PrimaryPart or carry:FindFirstChildWhichIsA("BasePart"))) or carry
-    if head and base and base:IsA("BasePart") then
+    if hrp and base and base:IsA("BasePart") then
         local weld = Instance.new("WeldConstraint")
         weld.Part0 = base
-        weld.Part1 = head :: BasePart
+        weld.Part1 = hrp :: BasePart
         weld.Parent = base
-        carry:PivotTo((head :: BasePart).CFrame * CFrame.new(0, 3.5, 0))
+        carry:PivotTo((hrp :: BasePart).CFrame * CFrame.new(0, 0, -2))
     end
     heldModel = carry
 end
@@ -234,6 +236,24 @@ end
 
 exitButton.Activated:Connect(function()
     cancelPlacement()
+end)
+
+RunService.Heartbeat:Connect(function()
+    if not placingItemId then
+        return
+    end
+    local character = player.Character
+    local hrp = character and character:FindFirstChild("HumanoidRootPart")
+    if not hrp then
+        return
+    end
+    local pos = hrp.Position
+    local within = pos.X >= plotBounds.min.X and pos.X <= plotBounds.max.X
+        and pos.Z >= plotBounds.min.Z and pos.Z <= plotBounds.max.Z
+        and pos.Y >= plotBounds.min.Y - 5 and pos.Y <= plotBounds.max.Y + 5
+    if not within then
+        cancelPlacement()
+    end
 end)
 
 function HeldItemController.startHold(item)

--- a/src/server/InventoryRemotes.luau
+++ b/src/server/InventoryRemotes.luau
@@ -3,6 +3,8 @@ local InventoryService = require(script.Parent:WaitForChild("InventoryService"))
 local BurstService = require(script.Parent:WaitForChild("BurstService"))
 local PlacementService = require(script.Parent:WaitForChild("PlacementService"))
 local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
+local SaveScheduler = require(script.Parent:WaitForChild("SaveScheduler"))
+local DataStoreAdapter = require(script.Parent:WaitForChild("DataStoreAdapter"))
 
 local Shared = ReplicatedStorage:WaitForChild("Shared")
 local ItemsConfig = require(Shared:WaitForChild("ItemsConfig"))
@@ -33,7 +35,14 @@ local rfPlace = Instance.new("RemoteFunction")
 rfPlace.Name = "RF_PlaceItem"
 rfPlace.Parent = ReplicatedStorage
 rfPlace.OnServerInvoke = function(player, typeId, plotId, worldCFrame)
-    return PlacementService.Place(player, typeId, plotId, worldCFrame)
+    local result = PlacementService.Place(player, typeId, plotId, worldCFrame)
+    if result.ok then
+        local data = PlayerManager.GetPlayerData(player)
+        SaveScheduler.enqueue(player.UserId, function()
+            DataStoreAdapter.Save(player, data)
+        end)
+    end
+    return result
 end
 
 local rfRemove = Instance.new("RemoteFunction")
@@ -127,6 +136,9 @@ evRequestPlace.OnServerEvent:Connect(function(player, typeId, worldCFrame)
         data.heldItem = nil
     end
     evConfirm:FireClient(player, true, { remaining = remaining, placedId = result.uid })
+    SaveScheduler.enqueue(player.UserId, function()
+        DataStoreAdapter.Save(player, data)
+    end)
 end)
 
 return {

--- a/src/server/PlacementService.luau
+++ b/src/server/PlacementService.luau
@@ -22,15 +22,40 @@ local rtypeof = typeof or function(obj)
     return type(obj)
 end
 
+local PLOT_PLATFORM_NAME = "Baseplate"
+
+local function getPlotBounds()
+    local platform
+    local ok, Workspace = pcall(function()
+        return game:GetService("Workspace")
+    end)
+    if ok and Workspace then
+        platform = Workspace:FindFirstChild(PLOT_PLATFORM_NAME)
+        if platform then
+            if platform:IsA("Model") then
+                local cf, size = platform:GetBoundingBox()
+                return cf.Position - size / 2, size
+            elseif platform:IsA("BasePart") then
+                local cf = platform.CFrame
+                return cf.Position - platform.Size / 2, platform.Size
+            end
+        end
+    end
+    return Vector3.new(-50, 0, -50), Vector3.new(100, 0, 100)
+end
+
 local function toLocal(cf)
-    if rtypeof(cf) == "CFrame" then
+    if rtypeof(cf) == "CFrame" or (type(cf) == "table" and cf.Position and cf.ToOrientation) then
         local px, py, pz = cf.Position.X, cf.Position.Y, cf.Position.Z
         local _, ry, _ = cf:ToOrientation()
-        return { px = px, py = py, pz = pz, ry = ry }
+        local min, size = getPlotBounds()
+        local rx = (px - min.X) / size.X
+        local rz = (pz - min.Z) / size.Z
+        return { rx = rx, rz = rz, y = py, ry = ry }
     elseif type(cf) == "table" then
         return cf
     else
-        return { px = 0, py = 0, pz = 0, ry = 0 }
+        return { rx = 0, rz = 0, y = 0, ry = 0 }
     end
 end
 

--- a/src/server/PlayerManager.luau
+++ b/src/server/PlayerManager.luau
@@ -68,18 +68,51 @@ local function getModel(modelName)
     return model:Clone()
 end
 
+local PLOT_PLATFORM_NAME = "Baseplate"
+
+local function getPlotBounds()
+    if not Workspace then
+        return Vector3.new(-50, 0, -50), Vector3.new(100, 0, 100)
+    end
+    local platform = Workspace:FindFirstChild(PLOT_PLATFORM_NAME)
+    if platform then
+        if platform:IsA("Model") then
+            local cf, size = platform:GetBoundingBox()
+            return cf.Position - size / 2, size
+        elseif platform:IsA("BasePart") then
+            local cf = platform.CFrame
+            return cf.Position - platform.Size / 2, platform.Size
+        end
+    end
+    return Vector3.new(-50, 0, -50), Vector3.new(100, 0, 100)
+end
+
 local function toWorld(cf)
     if type(cf) == "table" then
-        local px = cf.px or 0
-        local py = cf.py or 0
-        local pz = cf.pz or 0
+        local py = cf.y or cf.py or 0
         local ry = cf.ry or 0
-        if CFrame and CFrame.new then
-            local base = CFrame.new(px, py, pz)
-            if CFrame.Angles then
-                return base * CFrame.Angles(0, ry, 0)
-            else
-                return base
+        if cf.rx ~= nil and cf.rz ~= nil then
+            local min, size = getPlotBounds()
+            local px = min.X + cf.rx * size.X
+            local pz = min.Z + cf.rz * size.Z
+            if CFrame and CFrame.new then
+                local base = CFrame.new(px, py, pz)
+                if CFrame.Angles then
+                    return base * CFrame.Angles(0, ry, 0)
+                else
+                    return base
+                end
+            end
+        else
+            local px = cf.px or 0
+            local pz = cf.pz or 0
+            if CFrame and CFrame.new then
+                local base = CFrame.new(px, py, pz)
+                if CFrame.Angles then
+                    return base * CFrame.Angles(0, ry, 0)
+                else
+                    return base
+                end
             end
         end
     elseif typeof and typeof(cf) == "CFrame" then


### PR DESCRIPTION
## Summary
- Ghost preview now ghostifies entire model and strips all constraints
- Held items attach closer to the player and cancel if leaving plot bounds
- Store placed object coordinates relative to baseplate and save immediately after placement

## Testing
- `lua spec/economy_spec.lua`
- `lua spec/placement_persistence_spec.lua`
- `lua spec/aether_integration_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a0004aeb1c8327aa462e72259027cc