### PR TITLE
Fix overhead carry item placement

### DIFF
--- a/src/client/HeldItemController.luau
+++ b/src/client/HeldItemController.luau
@@ -121,17 +121,13 @@ local function pivotTo(cf: CFrame, modelOrPart: Instance)
     end
     if modelOrPart:IsA("Model") then
         local m = modelOrPart :: Model
-        if m.PrimaryPart then
-            m:SetPrimaryPartCFrame(cf)
-        else
+        if not m.PrimaryPart then
             local candidate = m:FindFirstChild("Primary") or m:FindFirstChild("Base") or m:FindFirstChildWhichIsA("BasePart")
             if candidate and candidate:IsA("BasePart") then
                 m.PrimaryPart = candidate
-                m:SetPrimaryPartCFrame(cf)
-            else
-                m:PivotTo(cf)
             end
         end
+        m:PivotTo(cf)
     end
 end
 
@@ -186,34 +182,74 @@ local function updateGhostAt(mouseHit: CFrame)
     pivotTo(cf, ghostModel)
 end
 
+local function ensurePrimaryPart(m: Model)
+    if m.PrimaryPart then
+        return
+    end
+    local root = m:FindFirstChild("Root") or m:FindFirstChildWhichIsA("BasePart")
+    if root then
+        m.PrimaryPart = root
+    end
+end
+
+local function stripExternalConstraints(m: Model)
+    for _, c in ipairs(m:GetDescendants()) do
+        if c:IsA("Constraint") then
+            local a0 = (c :: any).Attachment0
+            local a1 = (c :: any).Attachment1
+            local p0 = (c :: any).Part0
+            local p1 = (c :: any).Part1
+            if (a0 and not a0:IsDescendantOf(m)) or (a1 and not a1:IsDescendantOf(m))
+                or (p0 and not p0:IsDescendantOf(m)) or (p1 and not p1:IsDescendantOf(m)) then
+                c:Destroy()
+            end
+        elseif c:IsA("JointInstance") then
+            local p0 = (c :: any).Part0
+            local p1 = (c :: any).Part1
+            if (p0 and not p0:IsDescendantOf(m)) or (p1 and not p1:IsDescendantOf(m)) then
+                c:Destroy()
+            end
+        end
+    end
+end
+
 local function attachOverHead(character: Model, asset: Instance)
     if heldModel then heldModel:Destroy() end
 
     local carry = asset:Clone()
+    ensurePrimaryPart(carry)
     carry.Name = ("Carry_%s"):format(asset.Name)
-    carry.Parent = character
 
     for _, d in ipairs(carry:GetDescendants()) do
         if d:IsA("BasePart") then
-            d.Massless = true
-            d.CanCollide = false
             d.Anchored = false
-        elseif d:IsA("Weld") or d:IsA("WeldConstraint")
-            or d:IsA("Motor6D") or d:IsA("BallSocketConstraint")
-            or d:IsA("HingeConstraint") or d:IsA("RodConstraint") then
-            d:Destroy()
+            d.CanCollide = false
+            d.Massless = true
         end
     end
+    stripExternalConstraints(carry)
 
-    local hrp = character:FindFirstChild("HumanoidRootPart")
-    local base = (carry:IsA("Model") and (carry.PrimaryPart or carry:FindFirstChildWhichIsA("BasePart"))) or carry
-    if hrp and base and base:IsA("BasePart") then
-        local weld = Instance.new("WeldConstraint")
-        weld.Part0 = base
-        weld.Part1 = hrp :: BasePart
-        weld.Parent = base
-        carry:PivotTo((hrp :: BasePart).CFrame * CFrame.new(0, 0, -2))
+    local head = character:FindFirstChild("Head") or character:FindFirstChild("HumanoidRootPart")
+    if not head or not carry.PrimaryPart then
+        carry:Destroy()
+        return
     end
+
+    carry.Parent = character
+
+    local _, size = carry:GetBoundingBox()
+    local up = math.max(1.0, 0.5 * size.Y + 0.5)
+    local fwd = math.max(0.6, 0.25 * size.Z)
+    local offset = CFrame.new(0, up, -fwd)
+
+    carry:PivotTo((head :: BasePart).CFrame * offset)
+
+    local base = carry.PrimaryPart :: BasePart
+    local weld = Instance.new("WeldConstraint")
+    weld.Part0 = base
+    weld.Part1 = head :: BasePart
+    weld.Parent = base
+
     heldModel = carry
 end
 


### PR DESCRIPTION
## Summary
- add helpers to ensure primary part and strip external constraints for carried models
- pivot and weld carried item above the character's head with size-aware offsets
- keep ghost preview intact by pivoting entire model instead of just the root

## Testing
- ⚠️ `aftman install` (error sending request: invalid peer certificate)
- ⚠️ `rojo build -o "skyhunters.rbxlx"` (Rojo project referred to a file using $path that could not be turned into a Roblox Instance)
- ✅ `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a0146e51e48327ac9a44c667204927