### PR TITLE
Implement camera behavior management and equipped item UI

### DIFF
--- a/src/client/EquippedUI.luau
+++ b/src/client/EquippedUI.luau
@@ -1,0 +1,85 @@
+local Players = game:GetService("Players")
+
+local player = Players.LocalPlayer
+
+local EquippedUI = {}
+
+local screenGui: ScreenGui? = nil
+local frame: Frame? = nil
+local iconImage: ImageLabel? = nil
+local nameLabel: TextLabel? = nil
+local countLabel: TextLabel? = nil
+
+local function ensureGui()
+    if frame then
+        return
+    end
+    local playerGui = player:WaitForChild("PlayerGui")
+    screenGui = Instance.new("ScreenGui")
+    screenGui.Name = "EquippedUI"
+    screenGui.Parent = playerGui
+
+    frame = Instance.new("Frame")
+    frame.Size = UDim2.new(0, 160, 0, 50)
+    frame.Position = UDim2.new(0.5, -80, 1, -60)
+    frame.AnchorPoint = Vector2.new(0.5, 1)
+    frame.BackgroundColor3 = Color3.fromRGB(40, 40, 40)
+    frame.BackgroundTransparency = 0.3
+    frame.Visible = false
+    frame.Parent = screenGui
+
+    iconImage = Instance.new("ImageLabel")
+    iconImage.Size = UDim2.new(0, 50, 0, 50)
+    iconImage.BackgroundTransparency = 1
+    iconImage.Parent = frame
+
+    nameLabel = Instance.new("TextLabel")
+    nameLabel.Position = UDim2.new(0, 55, 0, 0)
+    nameLabel.Size = UDim2.new(1, -55, 0.5, 0)
+    nameLabel.BackgroundTransparency = 1
+    nameLabel.TextColor3 = Color3.new(1, 1, 1)
+    nameLabel.TextXAlignment = Enum.TextXAlignment.Left
+    nameLabel.Font = Enum.Font.SourceSans
+    nameLabel.TextSize = 18
+    nameLabel.Parent = frame
+
+    countLabel = Instance.new("TextLabel")
+    countLabel.Position = UDim2.new(0, 55, 0.5, 0)
+    countLabel.Size = UDim2.new(1, -55, 0.5, 0)
+    countLabel.BackgroundTransparency = 1
+    countLabel.TextColor3 = Color3.new(1, 1, 1)
+    countLabel.TextXAlignment = Enum.TextXAlignment.Left
+    countLabel.Font = Enum.Font.SourceSans
+    countLabel.TextSize = 18
+    countLabel.Parent = frame
+end
+
+function EquippedUI.Show(icon: string, name: string, count: number)
+    ensureGui()
+    if iconImage then
+        iconImage.Image = icon
+    end
+    if nameLabel then
+        nameLabel.Text = name
+    end
+    if countLabel then
+        countLabel.Text = tostring(count)
+    end
+    if frame then
+        frame.Visible = true
+    end
+end
+
+function EquippedUI.Update(count: number)
+    if countLabel then
+        countLabel.Text = tostring(count)
+    end
+end
+
+function EquippedUI.Hide()
+    if frame then
+        frame.Visible = false
+    end
+end
+
+return EquippedUI

--- a/src/client/HeldItemController.luau
+++ b/src/client/HeldItemController.luau
@@ -9,6 +9,8 @@ local ConfirmPlacement = ReplicatedStorage:WaitForChild("ConfirmPlacement")
 local PlacementRejected = ReplicatedStorage:WaitForChild("PlacementRejected")
 
 local ModelUtils = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("ModelUtils"))
+local EquippedUI = require(script.Parent:WaitForChild("EquippedUI"))
+local InventoryCountChanged = ReplicatedStorage:WaitForChild("InventoryCountChanged")
 
 local player = Players.LocalPlayer
 local mouse = player:GetMouse()
@@ -20,6 +22,9 @@ type ItemDef = {
     weldTo: "Head" | "HumanoidRootPart" | "RightHand",
     carryOffset: CFrame?,
     count: number?,
+    icon: string?,
+    name: string?,
+    cameraBehavior: string?,
 }
 
 local HeldItemController = {}
@@ -33,6 +38,10 @@ local lastMouseHit: CFrame? = nil
 local lastMouseOnPlatform = false
 local currentItemDef: ItemDef? = nil
 local currentMode: ("build" | "equip")? = nil
+
+local savedCameraMode: Enum.CameraMode? = nil
+local savedMinZoom: number? = nil
+local savedMaxZoom: number? = nil
 
 local GRID = 1
 local snapEnabled = false
@@ -147,23 +156,18 @@ local function spawnGhost(asset: Instance): Instance
     g.Parent = workspace
     local function ghostify(i: Instance)
         if i:IsA("BasePart") then
-            i.Transparency = 0.5
-            i.CanCollide = false
-            i.CanQuery = false
-            i.CanTouch = false
             i.Anchored = true
-        elseif i:IsA("Weld") or i:IsA("WeldConstraint") or i:IsA("Motor6D")
-            or i:IsA("BallSocketConstraint") or i:IsA("HingeConstraint")
-            or i:IsA("RodConstraint") then
-            i:Destroy()
+            i.CanCollide = false
+            i.Transparency = 0.5
+            i.Massless = true
         end
     end
     ghostify(g)
+    for _, d in ipairs(g:GetDescendants()) do
+        ghostify(d)
+    end
     if g:IsA("Model") then
         g:ScaleTo(1)
-        for _, d in ipairs(g:GetDescendants()) do
-            ghostify(d)
-        end
     end
     ghostModel = g
     return g
@@ -198,12 +202,16 @@ local function attachCarry(character: Model, asset: Instance, socketName: string
 
     carry.Name = ("Carry_%s"):format(asset.Name)
 
-    for _, d in ipairs(carry:GetDescendants()) do
-        if d:IsA("BasePart") then
-            d.Anchored = false
-            d.CanCollide = false
-            d.Massless = true
+    local function prep(part: Instance)
+        if part:IsA("BasePart") then
+            part.Anchored = false
+            part.CanCollide = false
+            part.Massless = true
         end
+    end
+    prep(carry)
+    for _, d in ipairs(carry:GetDescendants()) do
+        prep(d)
     end
   
     ModelUtils.stripExternalConstraints(carry)
@@ -252,6 +260,19 @@ local function cancelPlacement()
     lastMouseHit = nil
     lastMouseOnPlatform = false
     exitButton.Visible = false
+    if savedCameraMode then
+        player.CameraMode = savedCameraMode
+        if savedMinZoom then
+            player.CameraMinZoomDistance = savedMinZoom
+        end
+        if savedMaxZoom then
+            player.CameraMaxZoomDistance = savedMaxZoom
+        end
+    end
+    savedCameraMode = nil
+    savedMinZoom = nil
+    savedMaxZoom = nil
+    EquippedUI.Hide()
 end
 
 exitButton.Activated:Connect(function()
@@ -280,6 +301,9 @@ function HeldItemController.Start(itemDef: ItemDef, mode: "build" | "equip")
     end
     currentItemDef = itemDef
     currentMode = mode
+    savedCameraMode = player.CameraMode
+    savedMinZoom = player.CameraMinZoomDistance
+    savedMaxZoom = player.CameraMaxZoomDistance
     if mode == "build" then
         placingItemId = itemDef.id
         placingCount = itemDef.count or 1
@@ -296,6 +320,19 @@ function HeldItemController.Start(itemDef: ItemDef, mode: "build" | "equip")
         attachCarry(character, asset, itemDef.weldTo or "RightHand", itemDef.carryOffset)
         exitButton.Visible = true
     end
+    local behavior = itemDef.cameraBehavior or "free"
+    if behavior == "firstPerson" then
+        player.CameraMode = Enum.CameraMode.LockFirstPerson
+        player.CameraMinZoomDistance = 0.5
+        player.CameraMaxZoomDistance = 0.5
+    elseif behavior == "restricted" then
+        player.CameraMode = Enum.CameraMode.Classic
+        player.CameraMinZoomDistance = 6
+        player.CameraMaxZoomDistance = 12
+    else
+        player.CameraMode = Enum.CameraMode.Classic
+    end
+    EquippedUI.Show(itemDef.icon or "", itemDef.name or "", itemDef.count or placingCount or 1)
 end
 
 HeldItemController.Stop = cancelPlacement
@@ -310,7 +347,7 @@ function HeldItemController.GetCurrent()
 end
 
 local function tryPlace()
-    if not placingItemId or not ghostModel then
+    if not placingItemId or not ghostModel or placingCount <= 0 then
         return
     end
     local now = tick()
@@ -336,15 +373,17 @@ ConfirmPlacement.OnClientEvent:Connect(function(ok, payload)
         ghostModel = nil
     end
     placingCount = payload and payload.remaining or 0
-    if placingCount > 0 then
-        if lastMouseHit and lastMouseOnPlatform and currentTemplate then
-            spawnGhost(currentTemplate)
-            updateGhostAt(lastMouseHit)
-        end
-        -- else: wait for next mouse.Move to re-enter bounds before recreating the ghost
-    else
+    InventoryCountChanged:Fire(placingItemId, placingCount)
+    if placingCount <= 0 then
         HeldItemController.Stop()
+        return
     end
+    EquippedUI.Update(placingCount)
+    if lastMouseHit and lastMouseOnPlatform and currentTemplate then
+        spawnGhost(currentTemplate)
+        updateGhostAt(lastMouseHit)
+    end
+    -- else: wait for next mouse.Move to re-enter bounds before recreating the ghost
 end)
 
 PlacementRejected.OnClientEvent:Connect(function()

--- a/src/client/InventoryUI.luau
+++ b/src/client/InventoryUI.luau
@@ -5,6 +5,12 @@ local TweenService = game:GetService("TweenService")
 
 local InventoryConfig = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("InventoryConfig"))
 local ItemsConfig = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("ItemsConfig"))
+local CountChangedEvent = ReplicatedStorage:FindFirstChild("InventoryCountChanged")
+if not CountChangedEvent then
+    CountChangedEvent = Instance.new("BindableEvent")
+    CountChangedEvent.Name = "InventoryCountChanged"
+    CountChangedEvent.Parent = ReplicatedStorage
+end
 local HeldItemController = require(script.Parent:WaitForChild("HeldItemController"))
 
 local RF_Fetch = ReplicatedStorage:WaitForChild("Inventory_FetchPage")
@@ -48,6 +54,9 @@ local function createCell()
                     weldTo = "Head",
                     carryOffset = nil,
                     count = item.count,
+                    icon = cfg.icon,
+                    name = cfg.displayName,
+                    cameraBehavior = cfg.cameraBehavior,
                 }, "build")
             end
         end
@@ -82,6 +91,23 @@ local function renderGrid()
         table.insert(cells, cell)
     end
 end
+
+CountChangedEvent.Event:Connect(function(uid, newCount)
+    local item = itemLookup[uid]
+    if item then
+        item.count = newCount
+        if newCount <= 0 then
+            for i, existing in ipairs(items) do
+                if existing.uid == uid then
+                    table.remove(items, i)
+                    break
+                end
+            end
+            itemLookup[uid] = nil
+        end
+    end
+    renderGrid()
+end)
 
 local function fetchPage(reset)
     if reset then

--- a/src/shared/ItemsConfig.luau
+++ b/src/shared/ItemsConfig.luau
@@ -15,6 +15,7 @@ return {
             burstValue = 25,
             stackable = true,
             icon = "rbxassetid://0",
+            cameraBehavior = "firstPerson",
         },
 
         prod_cube_basic = {
@@ -25,6 +26,7 @@ return {
             model = "TestSeed",
             footprint = Vector3Util.new(2, 2, 2),
             icon = "rbxassetid://0",
+            cameraBehavior = "free",
         },
     },
 }


### PR DESCRIPTION
## Summary
- add `cameraBehavior` config to items and save/restore player camera when holding items
- separate ghost/carry creation and expose inventory count updates with UI refresh
- add EquippedUI module to show held item icon, name, and count

## Testing
- `lua spec/economy_spec.lua`

------
https://chatgpt.com/codex/tasks/task_e_68a046df06e48327b4275ec940cca19c