### PR TITLE
Add basic shop GUI and NPC interaction

### DIFF
--- a/src/client/ShopUI.luau
+++ b/src/client/ShopUI.luau
@@ -1,0 +1,78 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local localPlayer = Players.LocalPlayer
+
+local RF_FetchCatalog = ReplicatedStorage:WaitForChild("ShopRemotes"):WaitForChild("RF_FetchCatalog")
+local RF_Purchase = ReplicatedStorage.ShopRemotes:WaitForChild("RF_Purchase")
+
+local function createGui()
+    local playerGui = localPlayer:WaitForChild("PlayerGui")
+
+    local screenGui = Instance.new("ScreenGui")
+    screenGui.Name = "ShopGUI"
+    screenGui.Enabled = false
+    screenGui.Parent = playerGui
+
+    local frame = Instance.new("Frame")
+    frame.Size = UDim2.fromOffset(200, 100)
+    frame.Position = UDim2.fromScale(0.5, 0.5)
+    frame.AnchorPoint = Vector2.new(0.5, 0.5)
+    frame.BackgroundColor3 = Color3.fromRGB(40, 40, 40)
+    frame.BorderSizePixel = 0
+    frame.Parent = screenGui
+
+    local title = Instance.new("TextLabel")
+    title.Size = UDim2.new(1, 0, 0, 30)
+    title.BackgroundTransparency = 1
+    title.Text = "Shop"
+    title.TextColor3 = Color3.new(1, 1, 1)
+    title.Font = Enum.Font.SourceSansBold
+    title.TextSize = 16
+    title.Parent = frame
+
+    local close = Instance.new("TextButton")
+    close.Size = UDim2.new(0, 80, 0, 24)
+    close.Position = UDim2.new(1, -85, 1, -29)
+    close.BackgroundColor3 = Color3.fromRGB(60, 60, 60)
+    close.TextColor3 = Color3.new(1, 1, 1)
+    close.Text = "Close"
+    close.Parent = frame
+
+    close.MouseButton1Click:Connect(function()
+        screenGui.Enabled = false
+    end)
+
+    local buy = Instance.new("TextButton")
+    buy.Size = UDim2.new(0, 80, 0, 24)
+    buy.Position = UDim2.new(0, 5, 1, -29)
+    buy.BackgroundColor3 = Color3.fromRGB(60, 60, 60)
+    buy.TextColor3 = Color3.new(1, 1, 1)
+    buy.Text = "Buy Test"
+    buy.Parent = frame
+
+    buy.MouseButton1Click:Connect(function()
+        pcall(function()
+            RF_Purchase:InvokeServer({ itemId = "debug_item" })
+        end)
+    end)
+
+    return screenGui
+end
+
+local ShopUI = {}
+
+function ShopUI.Init()
+    local prompt = workspace:WaitForChild("ShopNPC"):WaitForChild("ProximityPrompt")
+    local gui = createGui()
+
+    prompt.Triggered:Connect(function()
+        gui.Enabled = true
+        pcall(function()
+            RF_FetchCatalog:InvokeServer()
+        end)
+    end)
+end
+
+return ShopUI
+

--- a/src/client/init.client.luau
+++ b/src/client/init.client.luau
@@ -159,3 +159,10 @@ if okInv then
     InventoryUI.Init()
 end
 
+local okShop, ShopUI = pcall(function()
+    return require(script:WaitForChild("ShopUI"))
+end)
+if okShop then
+    ShopUI.Init()
+end
+

--- a/src/server/init.server.luau
+++ b/src/server/init.server.luau
@@ -343,6 +343,24 @@ end
 
 createSellLever()
 
+local function createShopNPC()
+    local workspace = game:GetService("Workspace")
+    local npc = Instance.new("Part")
+    npc.Name = "ShopNPC"
+    npc.Size = Vector3.new(2, 5, 2)
+    npc.Anchored = true
+    npc.Position = Vector3.new(-6, 2.5, 0)
+    npc.Parent = workspace
+
+    local prompt = Instance.new("ProximityPrompt")
+    prompt.ActionText = "Shop"
+    prompt.ObjectText = "Shopkeeper"
+    prompt.HoldDuration = 0.75
+    prompt.Parent = npc
+end
+
+createShopNPC()
+
 -- Run test 2 seconds after server starts
 wait(2)
 runAetherTest()


### PR DESCRIPTION
## Summary
- Create simple ShopNPC with ProximityPrompt to open shop
- Add client ShopUI that fetches catalog and offers test purchase
- Load ShopUI from client init

## Testing
- `aftman install` *(fails: command not found)*
- `rojo build -o "skyhunters.rbxlx"` *(fails: command not found)*
- `lua spec/economy_spec.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0652de3c483279ae55ac81c18526b