### PR TITLE
Implement shop and loot services

### DIFF
--- a/src/serverstorage/LootService.luau
+++ b/src/serverstorage/LootService.luau
@@ -4,9 +4,9 @@
 -- Filters server-only items by tags; unobtainable/adminOnly are never granted.
 
 local ServerStorage = game:GetService("ServerStorage")
--- local InventoryService = require(ServerStorage.InventoryService)
--- local EconomyService = require(ServerStorage.EconomyService)
--- local ServerItemConfig = require(ServerStorage.ServerItemConfig)
+local InventoryService = require(ServerStorage:WaitForChild("InventoryService"))
+local Economy = require(ServerStorage:WaitForChild("Economy"))
+local ServerItemConfig = require(ServerStorage:WaitForChild("ServerItemConfig"))
 
 local LootService = {}
 
@@ -15,14 +15,38 @@ local function rng()
 end
 
 local function passesTags(def, includeTags, excludeTags)
-    -- TODO: implement according to your tag format (array or map)
+    local tags = def.tags or {}
+    if includeTags then
+        local found = false
+        for _, inc in ipairs(includeTags) do
+            for _, t in ipairs(tags) do
+                if t == inc then
+                    found = true
+                    break
+                end
+            end
+            if found then
+                break
+            end
+        end
+        if not found then
+            return false
+        end
+    end
+    if excludeTags then
+        for _, ex in ipairs(excludeTags) do
+            for _, t in ipairs(tags) do
+                if t == ex then
+                    return false
+                end
+            end
+        end
+    end
     return true
 end
 
 local function eligible(def)
-    -- Enforce obtainability/adminOnly server-side
-    -- return def and def.obtainable and not def.adminOnly
-    return true
+    return def and def.obtainable and not def.adminOnly
 end
 
 -- Weighting strategy is a policy choice; basic uniform for now.
@@ -41,35 +65,27 @@ function LootService.Roll(player, options)
     local includeTags = opts.includeTags
     local excludeTags = opts.excludeTags
 
-    -- Build server-side candidate pool
-    -- local pool = {}
-    -- for id, def in pairs(ServerItemConfig.items) do
-    --     if eligible(def) and passesTags(def, includeTags, excludeTags) then
-    --         if def.class == "Producer" then
-    --             table.insert(pool, { id = id, def = def })
-    --         end
-    --     end
-    -- end
+    local pool = {}
+    for id, def in pairs(ServerItemConfig.items) do
+        if def.class == "Producer" and eligible(def) and passesTags(def, includeTags, excludeTags) then
+            table.insert(pool, { id = id, weight = 1 })
+        end
+    end
 
     -- Use RNG
     local R = rng()
 
     for _ = 1, count do
-        -- Example: apply a flat fail roll with (1 - mod) chance if you want scarcity
-        -- if mod < 1 and R:NextNumber() > mod then
-        --     continue
-        -- end
-
-        -- local picked = pick(pool, R)
-        local picked = nil -- replace with actual pick
+        if mod < 1 and R:NextNumber() > mod then
+            continue
+        end
+        local picked = pick(pool, R)
         if picked then
-            -- Grant here (server-side):
-            -- InventoryService.AddItem(player, picked.id, 1)
+            InventoryService.Add(player, picked.id, 1)
             table.insert(drops, { id = picked.id, qty = 1 })
         end
     end
 
-    -- Optionally award currency here, same pattern, server-side only.
     return { ok = true, grants = drops }
 end
 

--- a/src/serverstorage/ServerItemConfig.luau
+++ b/src/serverstorage/ServerItemConfig.luau
@@ -1,0 +1,46 @@
+return {
+    items = {
+        prod_basic_common = {
+            class = "Producer",
+            price = 50,
+            rarity = "Common",
+            obtainable = true,
+            adminOnly = false,
+            tags = { "basic" },
+        },
+        prod_basic_uncommon = {
+            class = "Producer",
+            price = 200,
+            rarity = "Uncommon",
+            obtainable = true,
+            adminOnly = false,
+            tags = { "basic" },
+        },
+        prod_basic_rare = {
+            class = "Producer",
+            price = 750,
+            rarity = "Rare",
+            obtainable = true,
+            adminOnly = false,
+            tags = { "basic" },
+        },
+        prod_basic_legendary = {
+            class = "Producer",
+            price = 3000,
+            rarity = "Legendary",
+            obtainable = true,
+            adminOnly = false,
+            tags = { "basic" },
+        },
+        prod_basic_admin = {
+            class = "Producer",
+            price = 0,
+            rarity = "Mythic",
+            obtainable = false,
+            adminOnly = true,
+            tags = { "basic" },
+        },
+    },
+    rarityOrder = { "Common", "Uncommon", "Rare", "Legendary", "Mythic" },
+}
+

--- a/src/serverstorage/ShopService.luau
+++ b/src/serverstorage/ShopService.luau
@@ -5,11 +5,10 @@
 local ServerStorage = game:GetService("ServerStorage")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
--- TODO: require your real services:
--- local EconomyService = require(ServerStorage.EconomyService)
--- local InventoryService = require(ServerStorage.InventoryService)
--- local SaveScheduler = require(ServerStorage.SaveScheduler)
--- local ServerItemConfig = require(ServerStorage.ServerItemConfig) -- server-only truth
+local Economy = require(ServerStorage:WaitForChild("Economy"))
+local InventoryService = require(ServerStorage:WaitForChild("InventoryService"))
+local SaveScheduler = require(ServerStorage:WaitForChild("SaveScheduler"))
+local ServerItemConfig = require(ServerStorage:WaitForChild("ServerItemConfig"))
 local RateLimiter = require(ServerStorage.RateLimiter)
 local TxnLock = require(ServerStorage.TxnLock)
 
@@ -20,8 +19,7 @@ local FORCE_DURABLE_SAVE = true -- TODO: wire to your environment/flag system
 
 -- Returns a client-safe catalog (mapped elsewhere; don’t leak server flags here)
 function ShopService.FetchCatalog(player)
-    -- TODO: return require(ReplicatedStorage.Shared.PublicItemCatalog)
-    return {}
+    return require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("PublicItemCatalog"))
 end
 
 -- payload = { itemId: string, qty?: number (ignored/clamped to 1), txnId?: string }
@@ -40,50 +38,41 @@ function ShopService.Purchase(player, payload)
         return { ok = false, code = "RATE_LIMITED" }
     end
 
-    -- TODO: lookup server-only item def
-    -- local def = ServerItemConfig.items[itemId]
-    local def = nil -- replace
-    if not def then
+    local def = ServerItemConfig.items[itemId]
+    if not def or def.class ~= "Producer" then
         return { ok = false, code = "NOT_FOR_SALE" }
     end
-
-    -- Must be a BASIC PRODUCER variant (same model/behavior as debug producer)
-    -- if def.class ~= "Producer" then return { ok=false, code="NOT_FOR_SALE" } end
-
-    -- Enforce obtainability/adminOnly on the server
-    -- if not def.obtainable or def.adminOnly then return { ok=false, code="UNOBTAINABLE" } end
-
-    -- Price is server truth
-    -- local unitPrice = def.price or math.huge
-    local unitPrice = math.huge -- replace
-    local qty = 1 -- clamp to 1 for now
+    if not def.obtainable or def.adminOnly then
+        return { ok = false, code = "UNOBTAINABLE" }
+    end
+    local unitPrice = def.price or math.huge
+    local qty = 1
     local total = unitPrice * qty
 
     return TxnLock.withLock(player, "purchase", function()
-        -- Funds check and debit
-        -- if EconomyService.GetBalance(player, "crumbs") < total then
-        -- return { ok=false, code="INSUFFICIENT_FUNDS" }
-        -- end
-        -- EconomyService.Add(player, "crumbs", -total)
-
-        -- Grant item(s)
-        -- InventoryService.AddItem(player, itemId, qty)
+        if (player.crumbs or 0) < total then
+            return { ok = false, code = "INSUFFICIENT_FUNDS" }
+        end
+        if not Economy.ApplyCrumbsDelta(player, -total, "purchase") then
+            return { ok = false, code = "INSUFFICIENT_FUNDS" }
+        end
+        InventoryService.Add(player, itemId, qty)
 
         -- Persist
         if FORCE_DURABLE_SAVE then
             -- Minimal, blocking commit to avoid loss if the player leaves immediately.
             -- Prefer a targeted, fast-save path here.
-            -- local okSave = SaveScheduler.flushImmediate(player)
-            local okSave = true -- replace with your real call
+            local okSave = SaveScheduler.flushImmediate(player)
             if not okSave then
-                -- Roll back if desired:
-                -- EconomyService.Add(player, "crumbs", total)
-                -- InventoryService.AddItem(player, itemId, -qty)
+                Economy.ApplyCrumbsDelta(player, total, "refund")
+                InventoryService.Add(player, itemId, -qty)
                 return { ok = false, code = "SAVE_FAILED" }
             end
         else
             -- Normal path: enqueue/batch
-            -- SaveScheduler.enqueue(player.UserId, ...)
+            SaveScheduler.enqueue(player.UserId, function()
+                SaveScheduler.flushImmediate(player)
+            end)
         end
 
         -- Return authoritative result
@@ -91,8 +80,8 @@ function ShopService.Purchase(player, payload)
             ok = true,
             itemId = itemId,
             qtyGranted = qty,
-            -- newBalance = EconomyService.GetBalance(player, "crumbs"),
-            -- newCount = InventoryService.GetCount(player, itemId),
+            newBalance = player.crumbs,
+            newCount = (player.inventory and player.inventory[itemId]) or 0,
         }
     end)
 end

--- a/src/shared/ItemsConfig.luau
+++ b/src/shared/ItemsConfig.luau
@@ -28,6 +28,66 @@ return {
             icon = "rbxassetid://0",
             cameraBehavior = "free",
         },
+
+        prod_basic_common = {
+            category = "producers",
+            displayName = "Basic Producer",
+            rate = 0.5,
+            allowedSurface = "plot",
+            model = "TestSeed",
+            footprint = Vector3Util.new(2, 2, 2),
+            icon = "rbxassetid://0",
+            cameraBehavior = "free",
+            stackable = true,
+        },
+
+        prod_basic_uncommon = {
+            category = "producers",
+            displayName = "Sturdy Producer",
+            rate = 0.5,
+            allowedSurface = "plot",
+            model = "TestSeed",
+            footprint = Vector3Util.new(2, 2, 2),
+            icon = "rbxassetid://0",
+            cameraBehavior = "free",
+            stackable = true,
+        },
+
+        prod_basic_rare = {
+            category = "producers",
+            displayName = "Rare Producer",
+            rate = 0.5,
+            allowedSurface = "plot",
+            model = "TestSeed",
+            footprint = Vector3Util.new(2, 2, 2),
+            icon = "rbxassetid://0",
+            cameraBehavior = "free",
+            stackable = true,
+        },
+
+        prod_basic_legendary = {
+            category = "producers",
+            displayName = "Legendary Prod.",
+            rate = 0.5,
+            allowedSurface = "plot",
+            model = "TestSeed",
+            footprint = Vector3Util.new(2, 2, 2),
+            icon = "rbxassetid://0",
+            cameraBehavior = "free",
+            stackable = true,
+        },
+
+        prod_basic_admin = {
+            category = "producers",
+            displayName = "Admin Producer",
+            rate = 0.5,
+            allowedSurface = "plot",
+            model = "TestSeed",
+            footprint = Vector3Util.new(2, 2, 2),
+            icon = "rbxassetid://0",
+            cameraBehavior = "free",
+            stackable = true,
+        },
     },
 }
 

--- a/src/shared/PublicItemCatalog.luau
+++ b/src/shared/PublicItemCatalog.luau
@@ -1,0 +1,29 @@
+local items = {
+    prod_basic_common = {
+        name = "Basic Producer",
+        icon = "rbxassetid://0",
+        displayPrice = 50,
+        rarity = "Common",
+    },
+    prod_basic_uncommon = {
+        name = "Sturdy Producer",
+        icon = "rbxassetid://0",
+        displayPrice = 200,
+        rarity = "Uncommon",
+    },
+    prod_basic_rare = {
+        name = "Rare Producer",
+        icon = "rbxassetid://0",
+        displayPrice = 750,
+        rarity = "Rare",
+    },
+    prod_basic_legendary = {
+        name = "Legendary Prod.",
+        icon = "rbxassetid://0",
+        displayPrice = 3000,
+        rarity = "Legendary",
+    },
+}
+
+return { items = items, rarityOrder = { "Common", "Uncommon", "Rare", "Legendary" } }
+


### PR DESCRIPTION
## Summary
- add server item definitions and client catalog for producer variants
- implement ShopService purchase and catalog retrieval
- flesh out LootService with tag filtering and server-only drops

## Testing
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a0760fb5f4832787b8324722a85199