### PR TITLE
fix: load server modules from ServerScriptService

### DIFF
--- a/src/serverstorage/LootService.luau
+++ b/src/serverstorage/LootService.luau
@@ -4,8 +4,10 @@
 -- Filters server-only items by tags; unobtainable/adminOnly are never granted.
 
 local ServerStorage = game:GetService("ServerStorage")
-local InventoryService = require(ServerStorage:WaitForChild("InventoryService"))
-local Economy = require(ServerStorage:WaitForChild("Economy"))
+local ServerScriptService = game:GetService("ServerScriptService")
+
+local serverModules = ServerScriptService:WaitForChild("Server")
+local InventoryService = require(serverModules:WaitForChild("InventoryService"))
 local ServerItemConfig = require(ServerStorage:WaitForChild("ServerItemConfig"))
 
 local LootService = {}

--- a/src/serverstorage/ShopService.luau
+++ b/src/serverstorage/ShopService.luau
@@ -3,11 +3,13 @@
 -- Differences allowed: name, rarity, price. Everything else identical.
 
 local ServerStorage = game:GetService("ServerStorage")
+local ServerScriptService = game:GetService("ServerScriptService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local Economy = require(ServerStorage:WaitForChild("Economy"))
-local InventoryService = require(ServerStorage:WaitForChild("InventoryService"))
-local SaveScheduler = require(ServerStorage:WaitForChild("SaveScheduler"))
+local serverModules = ServerScriptService:WaitForChild("Server")
+local Economy = require(serverModules:WaitForChild("Economy"))
+local InventoryService = require(serverModules:WaitForChild("InventoryService"))
+local SaveScheduler = require(serverModules:WaitForChild("SaveScheduler"))
 local ServerItemConfig = require(ServerStorage:WaitForChild("ServerItemConfig"))
 local RateLimiter = require(ServerStorage.RateLimiter)
 local TxnLock = require(ServerStorage.TxnLock)


### PR DESCRIPTION
## Summary
- fix WaitForChild errors in server storage services by requiring modules from `ServerScriptService.Server`
- remove unused Economy dependency from loot service

## Testing
- `aftman install` *(fails: command not found)*
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a078e2b1048327b1fd5dca178db76f