### PR TITLE
Fix shop to use player data service

### DIFF
--- a/src/client/ShopUI.luau
+++ b/src/client/ShopUI.luau
@@ -14,6 +14,8 @@ local rarityColors = {
     Mythic = Color3.fromRGB(255, 0, 255),
 }
 
+local inventoryCount = {}
+
 local function createGui()
     local playerGui = localPlayer:WaitForChild("PlayerGui")
 
@@ -47,6 +49,14 @@ local function createGui()
     title.TextSize = 16
     title.Parent = frame
 
+    local crumbsLabel = Instance.new("TextLabel")
+    crumbsLabel.Size = UDim2.new(0, 80, 0, 24)
+    crumbsLabel.Position = UDim2.new(0, 5, 0, 5)
+    crumbsLabel.BackgroundTransparency = 1
+    crumbsLabel.TextColor3 = Color3.new(1, 1, 1)
+    crumbsLabel.Text = "0"
+    crumbsLabel.Parent = frame
+
     local close = Instance.new("TextButton")
     close.Size = UDim2.new(0, 80, 0, 24)
     close.Position = UDim2.new(1, -85, 0, 5)
@@ -76,10 +86,10 @@ local function createGui()
     list.BackgroundTransparency = 1
     list.Parent = frame
 
-    return screenGui, list, errorLabel
+    return screenGui, list, errorLabel, crumbsLabel
 end
 
-local function populateList(list, errorLabel)
+local function populateList(list, errorLabel, crumbsLabel)
     for _, child in ipairs(list:GetChildren()) do
         if child:IsA("Frame") then
             child:Destroy()
@@ -133,10 +143,8 @@ local function populateList(list, errorLabel)
                 buyButton.MouseButton1Click:Connect(function()
                     local result = RF_Purchase:InvokeServer({ itemId = id })
                     if result and result.ok then
-                        localPlayer.crumbs = result.newBalance
-                        local inv = localPlayer.inventory or {}
-                        inv[id] = result.newCount
-                        localPlayer.inventory = inv
+                        crumbsLabel.Text = tostring(result.newBalance)
+                        inventoryCount[id] = result.newCount
                         errorLabel.Text = "Purchased " .. (item.name or id)
                     else
                         errorLabel.Text = result and result.code or "Purchase failed"
@@ -154,11 +162,11 @@ local ShopUI = {}
 
 function ShopUI.Init()
     local prompt = workspace:WaitForChild("ShopNPC"):WaitForChild("ProximityPrompt")
-    local gui, list, errorLabel = createGui()
+    local gui, list, errorLabel, crumbsLabel = createGui()
 
     prompt.Triggered:Connect(function()
         gui.Enabled = true
-        populateList(list, errorLabel)
+        populateList(list, errorLabel, crumbsLabel)
     end)
 end
 

--- a/src/server/InventoryService.luau
+++ b/src/server/InventoryService.luau
@@ -36,6 +36,11 @@ function InventoryService.Consume(player, typeId, qty)
     return true
 end
 
+function InventoryService.GetCount(player, typeId)
+    local data = PlayerManager.GetPlayerData(player)
+    return data.inventory[typeId] or 0
+end
+
 function InventoryService.GetPage(player, category, search, cursor)
     local data = PlayerManager.GetPlayerData(player)
     local items = {}

--- a/src/serverstorage/ShopService.luau
+++ b/src/serverstorage/ShopService.luau
@@ -10,6 +10,7 @@ local serverModules = ServerScriptService:WaitForChild("Server")
 local Economy = require(serverModules:WaitForChild("Economy"))
 local InventoryService = require(serverModules:WaitForChild("InventoryService"))
 local SaveScheduler = require(serverModules:WaitForChild("SaveScheduler"))
+local PlayerManager = require(serverModules:WaitForChild("PlayerManager"))
 local ServerItemConfig = require(ServerStorage:WaitForChild("ServerItemConfig"))
 local RateLimiter = require(ServerStorage.RateLimiter)
 local TxnLock = require(ServerStorage.TxnLock)
@@ -52,13 +53,16 @@ function ShopService.Purchase(player, payload)
     local total = unitPrice * qty
 
     return TxnLock.withLock(player, "purchase", function()
-        if (player.crumbs or 0) < total then
+        local data = PlayerManager.GetPlayerData(player)
+        local balance = data.crumbs or 0
+        if balance < total then
             return { ok = false, code = "INSUFFICIENT_FUNDS" }
         end
-        if not Economy.ApplyCrumbsDelta(player, -total, "purchase") then
+        if not Economy.ApplyCrumbsDelta(data, -total, "purchase") then
             return { ok = false, code = "INSUFFICIENT_FUNDS" }
         end
         InventoryService.Add(player, itemId, qty)
+        local newCount = InventoryService.GetCount(player, itemId)
 
         -- Persist
         if FORCE_DURABLE_SAVE then
@@ -66,7 +70,7 @@ function ShopService.Purchase(player, payload)
             -- Prefer a targeted, fast-save path here.
             local okSave = SaveScheduler.flushImmediate(player)
             if not okSave then
-                Economy.ApplyCrumbsDelta(player, total, "refund")
+                Economy.ApplyCrumbsDelta(data, total, "rollback")
                 InventoryService.Add(player, itemId, -qty)
                 return { ok = false, code = "SAVE_FAILED" }
             end
@@ -82,8 +86,8 @@ function ShopService.Purchase(player, payload)
             ok = true,
             itemId = itemId,
             qtyGranted = qty,
-            newBalance = player.crumbs,
-            newCount = (player.inventory and player.inventory[itemId]) or 0,
+            newBalance = data.crumbs,
+            newCount = newCount,
         }
     end)
 end


### PR DESCRIPTION
## Summary
- use PlayerManager-backed data in ShopService to validate balance, apply currency changes, and return updated counts
- expose InventoryService.GetCount and update client ShopUI to rely on server responses instead of Player members

## Testing
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a08148ae4c8327a223ef1613cfc22a