### PR TITLE
feat: add shop snapshot and item switch

### DIFF
--- a/src/client/HeldItemController.luau
+++ b/src/client/HeldItemController.luau
@@ -11,6 +11,7 @@ local PlacementRejected = ReplicatedStorage:WaitForChild("PlacementRejected")
 local ModelUtils = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("ModelUtils"))
 local EquippedUI = require(script.Parent:WaitForChild("EquippedUI"))
 local InventoryCountChanged = ReplicatedStorage:WaitForChild("InventoryCountChanged")
+local ItemsConfig = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("ItemsConfig"))
 
 local player = Players.LocalPlayer
 local mouse = player:GetMouse()
@@ -337,7 +338,34 @@ end
 
 HeldItemController.Stop = cancelPlacement
 
-function HeldItemController.Switch(itemDef: ItemDef, mode: "build" | "equip")
+local function buildItemDef(itemId: string, mode: "build" | "equip"): ItemDef?
+    local cfg = ItemsConfig.Types[itemId]
+    if not cfg then
+        return nil
+    end
+    -- TODO: fetch actual inventory count
+    local def: ItemDef = {
+        id = itemId,
+        model = cfg.model,
+        weldTo = mode == "build" and "Head" or "RightHand",
+        carryOffset = nil,
+        count = 1,
+        icon = cfg.icon,
+        name = cfg.displayName,
+        cameraBehavior = cfg.cameraBehavior,
+    }
+    return def
+end
+
+function HeldItemController.Switch(itemId: string, mode: "build" | "equip")
+    local current, currentMode = HeldItemController.GetCurrent()
+    if current and current.id == itemId and currentMode == mode then
+        return
+    end
+    local itemDef = buildItemDef(itemId, mode)
+    if not itemDef then
+        return
+    end
     HeldItemController.Stop()
     HeldItemController.Start(itemDef, mode)
 end

--- a/src/client/InventoryUI.luau
+++ b/src/client/InventoryUI.luau
@@ -4,7 +4,6 @@ local RunService = game:GetService("RunService")
 local TweenService = game:GetService("TweenService")
 
 local InventoryConfig = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("InventoryConfig"))
-local ItemsConfig = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("ItemsConfig"))
 local CountChangedEvent = ReplicatedStorage:FindFirstChild("InventoryCountChanged")
 if not CountChangedEvent then
     CountChangedEvent = Instance.new("BindableEvent")
@@ -45,20 +44,11 @@ local function createCell()
         end
         local item = itemLookup[uid]
         if item then
-            local cfg = ItemsConfig.Types[item.typeId]
-            if cfg then
-                HeldItemController.Start({
-                    id = item.uid,
-                    model = cfg.model,
-                    type = "Build",
-                    weldTo = "Head",
-                    carryOffset = nil,
-                    count = item.count,
-                    icon = cfg.icon,
-                    name = cfg.displayName,
-                    cameraBehavior = cfg.cameraBehavior,
-                }, "build")
+            local current, mode = HeldItemController.GetCurrent()
+            if current and current.id == item.uid and mode == "build" then
+                return
             end
+            HeldItemController.Switch(item.uid, "build")
         end
     end)
     return frame

--- a/src/client/ShopUI.luau
+++ b/src/client/ShopUI.luau
@@ -3,7 +3,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local localPlayer = Players.LocalPlayer
 
-local RF_FetchCatalog = ReplicatedStorage:WaitForChild("ShopRemotes"):WaitForChild("RF_FetchCatalog")
+local RF_FetchShopSnapshot = ReplicatedStorage:WaitForChild("ShopRemotes"):WaitForChild("RF_FetchShopSnapshot")
 local RF_Purchase = ReplicatedStorage.ShopRemotes:WaitForChild("RF_Purchase")
 
 local rarityColors = {
@@ -16,13 +16,18 @@ local rarityColors = {
 
 local inventoryCount = {}
 
+local screenGui
+local list
+local errorLabel
+local crumbsLabel
+
 local function createGui()
     local playerGui = localPlayer:WaitForChild("PlayerGui")
 
-    local screenGui = Instance.new("ScreenGui")
-    screenGui.Name = "ShopGUI"
-    screenGui.Enabled = false
-    screenGui.Parent = playerGui
+    local gui = Instance.new("ScreenGui")
+    gui.Name = "ShopGUI"
+    gui.Enabled = false
+    gui.Parent = playerGui
 
     local plate = Instance.new("ImageLabel")
     plate.Name = "Plate"
@@ -31,7 +36,7 @@ local function createGui()
     plate.AnchorPoint = Vector2.new(0.5, 0.5)
     plate.BackgroundTransparency = 1
     plate.Image = "rbxassetid://0"
-    plate.Parent = screenGui
+    plate.Parent = gui
 
     local frame = Instance.new("Frame")
     frame.Size = UDim2.new(1, -20, 1, -20)
@@ -49,13 +54,13 @@ local function createGui()
     title.TextSize = 16
     title.Parent = frame
 
-    local crumbsLabel = Instance.new("TextLabel")
-    crumbsLabel.Size = UDim2.new(0, 80, 0, 24)
-    crumbsLabel.Position = UDim2.new(0, 5, 0, 5)
-    crumbsLabel.BackgroundTransparency = 1
-    crumbsLabel.TextColor3 = Color3.new(1, 1, 1)
-    crumbsLabel.Text = "0"
-    crumbsLabel.Parent = frame
+    local crumb = Instance.new("TextLabel")
+    crumb.Size = UDim2.new(0, 80, 0, 24)
+    crumb.Position = UDim2.new(0, 5, 0, 5)
+    crumb.BackgroundTransparency = 1
+    crumb.TextColor3 = Color3.new(1, 1, 1)
+    crumb.Text = "0"
+    crumb.Parent = frame
 
     local close = Instance.new("TextButton")
     close.Size = UDim2.new(0, 80, 0, 24)
@@ -65,31 +70,35 @@ local function createGui()
     close.Text = "Close"
     close.Parent = frame
     close.MouseButton1Click:Connect(function()
-        screenGui.Enabled = false
+        gui.Enabled = false
     end)
 
-    local errorLabel = Instance.new("TextLabel")
-    errorLabel.Size = UDim2.new(1, -10, 0, 20)
-    errorLabel.Position = UDim2.new(0, 5, 1, -25)
-    errorLabel.BackgroundTransparency = 1
-    errorLabel.TextColor3 = Color3.new(1, 0.3, 0.3)
-    errorLabel.Text = ""
-    errorLabel.TextSize = 14
-    errorLabel.Parent = frame
+    local err = Instance.new("TextLabel")
+    err.Size = UDim2.new(1, -10, 0, 20)
+    err.Position = UDim2.new(0, 5, 1, -25)
+    err.BackgroundTransparency = 1
+    err.TextColor3 = Color3.new(1, 0.3, 0.3)
+    err.Text = ""
+    err.TextSize = 14
+    err.Parent = frame
 
-    local list = Instance.new("ScrollingFrame")
-    list.Name = "List"
-    list.Size = UDim2.new(1, -10, 1, -60)
-    list.Position = UDim2.new(0, 5, 0, 35)
-    list.CanvasSize = UDim2.new(0, 0, 0, 0)
-    list.ScrollBarThickness = 6
-    list.BackgroundTransparency = 1
-    list.Parent = frame
+    local listFrame = Instance.new("ScrollingFrame")
+    listFrame.Name = "List"
+    listFrame.Size = UDim2.new(1, -10, 1, -60)
+    listFrame.Position = UDim2.new(0, 5, 0, 35)
+    listFrame.CanvasSize = UDim2.new(0, 0, 0, 0)
+    listFrame.ScrollBarThickness = 6
+    listFrame.BackgroundTransparency = 1
+    listFrame.Parent = frame
 
-    return screenGui, list, errorLabel, crumbsLabel
+    screenGui = gui
+    list = listFrame
+    errorLabel = err
+    crumbsLabel = crumb
+    return gui
 end
 
-local function populateList(list, errorLabel, crumbsLabel)
+local function populateList(catalog)
     for _, child in ipairs(list:GetChildren()) do
         if child:IsA("Frame") then
             child:Destroy()
@@ -97,7 +106,6 @@ local function populateList(list, errorLabel, crumbsLabel)
     end
     errorLabel.Text = ""
 
-    local catalog = RF_FetchCatalog:InvokeServer()
     if typeof(catalog) ~= "table" or typeof(catalog.items) ~= "table" then
         errorLabel.Text = "Failed to load catalog"
         return
@@ -160,15 +168,27 @@ end
 
 local ShopUI = {}
 
-function ShopUI.Init()
-    local prompt = workspace:WaitForChild("ShopNPC"):WaitForChild("ProximityPrompt")
-    local gui, list, errorLabel, crumbsLabel = createGui()
-
-    prompt.Triggered:Connect(function()
-        gui.Enabled = true
-        populateList(list, errorLabel, crumbsLabel)
-    end)
+local function open()
+    if not screenGui then
+        createGui()
+    end
+    screenGui.Enabled = true
+    local snapshot = RF_FetchShopSnapshot:InvokeServer()
+    if typeof(snapshot) ~= "table" then
+        errorLabel.Text = "Failed to load catalog"
+        return
+    end
+    crumbsLabel.Text = tostring(snapshot.balance or 0)
+    populateList(snapshot.catalog)
 end
+
+function ShopUI.Init()
+    createGui()
+    local prompt = workspace:WaitForChild("ShopNPC"):WaitForChild("ProximityPrompt")
+    prompt.Triggered:Connect(open)
+end
+
+ShopUI.Open = open
 
 return ShopUI
 

--- a/src/server/AttachmentService.luau
+++ b/src/server/AttachmentService.luau
@@ -1,0 +1,18 @@
+local AttachmentService = {}
+
+function AttachmentService.EquipAttachment(player, slot, itemId)
+    -- TODO: equip attachment and persist
+    return false, "NOT_IMPLEMENTED"
+end
+
+function AttachmentService.GetAttachments(player)
+    -- TODO: return equipped attachment ids
+    return { nil, nil }
+end
+
+function AttachmentService.ComputeAttachmentModifiers(player)
+    -- TODO: compute movement and fire rate modifiers
+    return {}
+end
+
+return AttachmentService

--- a/src/server/BurstService.luau
+++ b/src/server/BurstService.luau
@@ -30,5 +30,10 @@ function BurstService.Use(player, typeId)
     return { ok = true }
 end
 
+function BurstService.Interact(player, uid)
+    -- TODO: convert growth into aether; allow overflow that decays
+    return { ok = false, code = "NOT_IMPLEMENTED" }
+end
+
 return BurstService
 

--- a/src/server/CombatRemotes.server.luau
+++ b/src/server/CombatRemotes.server.luau
@@ -1,0 +1,16 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local remotesFolder = ReplicatedStorage:FindFirstChild("Remotes")
+if not remotesFolder then
+    remotesFolder = Instance.new("Folder")
+    remotesFolder.Name = "Remotes"
+    remotesFolder.Parent = ReplicatedStorage
+end
+
+local combatFolder = Instance.new("Folder")
+combatFolder.Name = "Combat"
+combatFolder.Parent = remotesFolder
+
+local firePrimary = Instance.new("RemoteEvent")
+firePrimary.Name = "FirePrimary"
+firePrimary.Parent = combatFolder

--- a/src/server/CombatService.luau
+++ b/src/server/CombatService.luau
@@ -1,0 +1,9 @@
+local CombatService = {}
+
+function CombatService.FirePrimary(player, payload)
+    -- TODO: validate fire rate and apply damage
+    local weaponId = payload and payload.weaponId or "unknown"
+    print("[COMBAT] FIRE", player.UserId, weaponId, "hits=0")
+end
+
+return CombatService

--- a/src/server/CurseService.luau
+++ b/src/server/CurseService.luau
@@ -1,0 +1,21 @@
+local CurseService = {}
+
+function CurseService.GrantCurse(player, curseId, stacks, ttl)
+    -- TODO: add curse to player data
+end
+
+function CurseService.RemoveCurse(player, curseId, stacks)
+    -- TODO: remove or decrement curse
+end
+
+function CurseService.GetCurses(player)
+    -- TODO: return active curses for player
+    return {}
+end
+
+function CurseService.ApplyToStats(base, curses)
+    -- TODO: apply curse modifiers to stats
+    return base
+end
+
+return CurseService

--- a/src/server/DayNightService.luau
+++ b/src/server/DayNightService.luau
@@ -1,0 +1,16 @@
+local DayNightService = {}
+
+function DayNightService.SetCycleLength(seconds)
+    -- TODO: set day/night cycle length
+end
+
+function DayNightService.GetTimeOfDay()
+    -- TODO: return normalized time of day
+    return 0
+end
+
+function DayNightService.Tick(dt)
+    -- TODO: advance time and broadcast changes
+end
+
+return DayNightService

--- a/src/server/DropsService.luau
+++ b/src/server/DropsService.luau
@@ -1,0 +1,73 @@
+local ServerStorage = game:GetService("ServerStorage")
+local ServerScriptService = game:GetService("ServerScriptService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local HttpService = game:GetService("HttpService")
+
+local serverModules = ServerScriptService:WaitForChild("Server")
+local InventoryService = require(serverModules:WaitForChild("InventoryService"))
+local ServerItemConfig = require(ServerStorage:WaitForChild("ServerItemConfig"))
+
+local DropsService = {}
+
+function DropsService.Roll(player, opts)
+    if typeof(opts) ~= "table" then
+        print("[DROPS] ROLL", player.UserId, "drops=[]")
+        return { ok = false, grants = {} }
+    end
+    local numDrops = math.clamp(opts.numDrops or 0, 1, 20)
+    local chance = opts.chanceModifier or 1
+    chance = math.clamp(chance, 0, 1)
+    local includeTags = opts.includeTags
+    local excludeTags = opts.excludeTags
+
+    local pool = {}
+    for id, def in pairs(ServerItemConfig.items) do
+        if def.obtainable and not def.adminOnly then
+            local tags = def.tags or {}
+            local ok = true
+            if includeTags then
+                for _, tag in ipairs(includeTags) do
+                    if not table.find(tags, tag) then
+                        ok = false
+                        break
+                    end
+                end
+            end
+            if ok and excludeTags then
+                for _, tag in ipairs(excludeTags) do
+                    if table.find(tags, tag) then
+                        ok = false
+                        break
+                    end
+                end
+            end
+            if ok then
+                table.insert(pool, id)
+            end
+        end
+    end
+
+    local grants = {}
+    if #pool > 0 then
+        for _ = 1, numDrops do
+            if math.random() <= chance then
+                local itemId = pool[math.random(1, #pool)]
+                InventoryService.Add(player, itemId, 1)
+                table.insert(grants, { id = itemId, qty = 1 })
+            end
+        end
+    end
+
+    local dropsJson = "[]"
+    local okEncode, encoded = pcall(function()
+        return HttpService:JSONEncode(grants)
+    end)
+    if okEncode then
+        dropsJson = encoded
+    end
+    print("[DROPS] ROLL", player.UserId, "drops=" .. dropsJson)
+
+    return { ok = true, grants = grants }
+end
+
+return DropsService

--- a/src/server/EventService.luau
+++ b/src/server/EventService.luau
@@ -1,0 +1,20 @@
+local EventService = {}
+
+function EventService.Schedule(id, at, data)
+    -- TODO: schedule an event
+end
+
+function EventService.StartNow(id, data)
+    -- TODO: start event immediately
+end
+
+function EventService.End(id)
+    -- TODO: end active event
+end
+
+function EventService.GetActive()
+    -- TODO: return active events
+    return {}
+end
+
+return EventService

--- a/src/server/FameService.luau
+++ b/src/server/FameService.luau
@@ -1,0 +1,13 @@
+local FameService = {}
+
+function FameService.AddFameFromValue(player, value)
+    -- TODO: map sell value to fame using sigmoid
+    return 0
+end
+
+function FameService.GetFame(player)
+    -- TODO: return current fame from player data
+    return 0
+end
+
+return FameService

--- a/src/server/GrowthService.luau
+++ b/src/server/GrowthService.luau
@@ -1,0 +1,20 @@
+local GrowthService = {}
+
+function GrowthService.RegisterProducer(player, uid, seed)
+    -- TODO: track producer growth state
+end
+
+function GrowthService.UnregisterProducer(player, uid)
+    -- TODO: remove tracked producer
+end
+
+function GrowthService.Tick(dt)
+    -- TODO: advance growth values and branch generation
+end
+
+function GrowthService.GetSnapshot(player)
+    -- TODO: return growth and branch snapshot for player
+    return {}
+end
+
+return GrowthService

--- a/src/server/MinionService.luau
+++ b/src/server/MinionService.luau
@@ -1,0 +1,15 @@
+local MinionService = {}
+
+function MinionService.SyncForPlayer(player)
+    -- TODO: spawn or update minions around base
+end
+
+function MinionService.OnSellAether(player, amount)
+    -- TODO: react to aether sales for celebration
+end
+
+function MinionService.Tick(dt)
+    -- TODO: update minion state machines
+end
+
+return MinionService

--- a/src/server/ShopRemotes.server.luau
+++ b/src/server/ShopRemotes.server.luau
@@ -16,6 +16,10 @@ local RF_Purchase = Instance.new("RemoteFunction")
 RF_Purchase.Name = "RF_Purchase"
 RF_Purchase.Parent = folder
 
+local RF_FetchShopSnapshot = Instance.new("RemoteFunction")
+RF_FetchShopSnapshot.Name = "RF_FetchShopSnapshot"
+RF_FetchShopSnapshot.Parent = folder
+
 local ShopService = require(ServerStorage.ShopService)
 
 RF_FetchCatalog.OnServerInvoke = function(player)
@@ -24,4 +28,8 @@ end
 
 RF_Purchase.OnServerInvoke = function(player, payload)
     return ShopService.Purchase(player, payload)
+end
+
+RF_FetchShopSnapshot.OnServerInvoke = function(player)
+    return ShopService.FetchShopSnapshot(player)
 end

--- a/src/server/WeaponService.luau
+++ b/src/server/WeaponService.luau
@@ -1,0 +1,13 @@
+local WeaponService = {}
+
+function WeaponService.EquipWeapon(player, weaponId)
+    -- TODO: equip weapon for player
+    return false, "NOT_IMPLEMENTED"
+end
+
+function WeaponService.GetEquippedWeapon(player)
+    -- TODO: return equipped weapon id
+    return nil
+end
+
+return WeaponService

--- a/src/server/WorldGenService.luau
+++ b/src/server/WorldGenService.luau
@@ -1,0 +1,17 @@
+local WorldGenService = {}
+
+function WorldGenService.SpawnIsland(spec)
+    -- TODO: assemble island from prefabs
+    return 0
+end
+
+function WorldGenService.DespawnIsland(islandId)
+    -- TODO: remove spawned island
+end
+
+function WorldGenService.GetIslands()
+    -- TODO: return current islands
+    return {}
+end
+
+return WorldGenService

--- a/src/serverstorage/ShopService.luau
+++ b/src/serverstorage/ShopService.luau
@@ -25,28 +25,40 @@ function ShopService.FetchCatalog(player)
     return require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("PublicItemCatalog"))
 end
 
+function ShopService.FetchShopSnapshot(player)
+    local catalog = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("PublicItemCatalog"))
+    local data = PlayerManager.GetPlayerData(player)
+    local balance = data.crumbs or 0
+    return { catalog = catalog, balance = balance }
+end
+
 -- payload = { itemId: string, qty?: number (ignored/clamped to 1), txnId?: string }
 function ShopService.Purchase(player, payload)
+    local function deny(code)
+        print("[SHOP] PURCHASE_DENY", player.UserId, code)
+        return { ok = false, code = code }
+    end
+
     -- Basic input validation
     if typeof(payload) ~= "table" then
-        return { ok = false, code = "BAD_REQUEST" }
+        return deny("BAD_REQUEST")
     end
     local itemId = payload.itemId
     if typeof(itemId) ~= "string" then
-        return { ok = false, code = "BAD_REQUEST" }
+        return deny("BAD_REQUEST")
     end
 
     -- Rate limit (small window)
     if not RateLimiter.Allow(player, "purchase", 6, 3.0) then
-        return { ok = false, code = "RATE_LIMITED" }
+        return deny("RATE_LIMITED")
     end
 
     local def = ServerItemConfig.items[itemId]
     if not def or def.class ~= "Producer" then
-        return { ok = false, code = "NOT_FOR_SALE" }
+        return deny("NOT_FOR_SALE")
     end
     if not def.obtainable or def.adminOnly then
-        return { ok = false, code = "UNOBTAINABLE" }
+        return deny("UNOBTAINABLE")
     end
     local unitPrice = def.price or math.huge
     local qty = 1
@@ -56,10 +68,10 @@ function ShopService.Purchase(player, payload)
         local data = PlayerManager.GetPlayerData(player)
         local balance = data.crumbs or 0
         if balance < total then
-            return { ok = false, code = "INSUFFICIENT_FUNDS" }
+            return deny("INSUFFICIENT_FUNDS")
         end
         if not Economy.ApplyCrumbsDelta(data, -total, "purchase") then
-            return { ok = false, code = "INSUFFICIENT_FUNDS" }
+            return deny("INSUFFICIENT_FUNDS")
         end
         InventoryService.Add(player, itemId, qty)
         local newCount = InventoryService.GetCount(player, itemId)
@@ -72,7 +84,7 @@ function ShopService.Purchase(player, payload)
             if not okSave then
                 Economy.ApplyCrumbsDelta(data, total, "rollback")
                 InventoryService.Add(player, itemId, -qty)
-                return { ok = false, code = "SAVE_FAILED" }
+                return deny("SAVE_FAILED")
             end
         else
             -- Normal path: enqueue/batch
@@ -80,6 +92,8 @@ function ShopService.Purchase(player, payload)
                 SaveScheduler.flushImmediate(player)
             end)
         end
+
+        print("[SHOP] PURCHASE_OK", player.UserId, itemId, total, "balance=" .. tostring(data.crumbs))
 
         -- Return authoritative result
         return {


### PR DESCRIPTION
## Summary
- allow immediate item swapping via HeldItemController.Switch
- fix shop UI to fetch balance+catalog snapshot and log purchases
- add server-side drop rolling and future service skeletons

## Testing
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a0976042bc832789acaf88c383246f