### PR TITLE
feat: centralize inventory counts and document stubs

### DIFF
--- a/src/client/HeldItemController.luau
+++ b/src/client/HeldItemController.luau
@@ -12,6 +12,7 @@ local ModelUtils = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild
 local EquippedUI = require(script.Parent:WaitForChild("EquippedUI"))
 local InventoryCountChanged = ReplicatedStorage:WaitForChild("InventoryCountChanged")
 local ItemsConfig = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("ItemsConfig"))
+local InventoryState = require(script.Parent:WaitForChild("InventoryState"))
 
 local player = Players.LocalPlayer
 local mouse = player:GetMouse()
@@ -31,7 +32,6 @@ type ItemDef = {
 local HeldItemController = {}
 
 local placingItemId: string? = nil
-local placingCount = 0
 local heldModel: Instance? = nil
 local ghostModel: Instance? = nil
 local currentTemplate: Instance? = nil
@@ -246,7 +246,6 @@ end
 
 local function cancelPlacement()
     placingItemId = nil
-    placingCount = 0
     currentTemplate = nil
     currentItemDef = nil
     currentMode = nil
@@ -307,7 +306,6 @@ function HeldItemController.Start(itemDef: ItemDef, mode: "build" | "equip")
     savedMaxZoom = player.CameraMaxZoomDistance
     if mode == "build" then
         placingItemId = itemDef.id
-        placingCount = itemDef.count or 1
         StartHolding:FireServer(itemDef.id)
         currentTemplate = getModel(itemDef.model)
         local character = player.Character or player.CharacterAdded:Wait()
@@ -333,7 +331,8 @@ function HeldItemController.Start(itemDef: ItemDef, mode: "build" | "equip")
     else
         player.CameraMode = Enum.CameraMode.Classic
     end
-    EquippedUI.Show(itemDef.icon or "", itemDef.name or "", itemDef.count or placingCount or 1)
+    local count = InventoryState.GetCount(itemDef.id)
+    EquippedUI.Show(itemDef.icon or "", itemDef.name or "", count)
 end
 
 HeldItemController.Stop = cancelPlacement
@@ -375,7 +374,7 @@ function HeldItemController.GetCurrent()
 end
 
 local function tryPlace()
-    if not placingItemId or not ghostModel or placingCount <= 0 then
+    if not placingItemId or not ghostModel or InventoryState.GetCount(placingItemId) <= 0 then
         return
     end
     local now = tick()
@@ -400,13 +399,14 @@ ConfirmPlacement.OnClientEvent:Connect(function(ok, payload)
         ghostModel:Destroy()
         ghostModel = nil
     end
-    placingCount = payload and payload.remaining or 0
-    InventoryCountChanged:Fire(placingItemId, placingCount)
-    if placingCount <= 0 then
+    local newCount = payload and payload.remaining or 0
+    InventoryState.SetCount(placingItemId, newCount)
+    InventoryCountChanged:Fire(placingItemId, newCount)
+    if newCount <= 0 then
         HeldItemController.Stop()
         return
     end
-    EquippedUI.Update(placingCount)
+    EquippedUI.Update(newCount)
     if lastMouseHit and lastMouseOnPlatform and currentTemplate then
         spawnGhost(currentTemplate)
         updateGhostAt(lastMouseHit)

--- a/src/client/InventoryState.luau
+++ b/src/client/InventoryState.luau
@@ -1,0 +1,13 @@
+local InventoryState = {}
+
+local counts = {}
+
+function InventoryState.SetCount(uid: string, count: number)
+    counts[uid] = count
+end
+
+function InventoryState.GetCount(uid: string): number
+    return counts[uid] or 0
+end
+
+return InventoryState

--- a/src/client/InventoryUI.luau
+++ b/src/client/InventoryUI.luau
@@ -11,6 +11,7 @@ if not CountChangedEvent then
     CountChangedEvent.Parent = ReplicatedStorage
 end
 local HeldItemController = require(script.Parent:WaitForChild("HeldItemController"))
+local InventoryState = require(script.Parent:WaitForChild("InventoryState"))
 
 local RF_Fetch = ReplicatedStorage:WaitForChild("Inventory_FetchPage")
 
@@ -96,6 +97,7 @@ CountChangedEvent.Event:Connect(function(uid, newCount)
             itemLookup[uid] = nil
         end
     end
+    InventoryState.SetCount(uid, newCount)
     renderGrid()
 end)
 
@@ -109,6 +111,7 @@ local function fetchPage(reset)
     for _, item in ipairs(page) do
         table.insert(items, item)
         itemLookup[item.uid] = item
+        InventoryState.SetCount(item.uid, item.count)
     end
     nextCursor = newCursor
 end

--- a/src/client/ShopUI.luau
+++ b/src/client/ShopUI.luau
@@ -5,6 +5,8 @@ local localPlayer = Players.LocalPlayer
 
 local RF_FetchShopSnapshot = ReplicatedStorage:WaitForChild("ShopRemotes"):WaitForChild("RF_FetchShopSnapshot")
 local RF_Purchase = ReplicatedStorage.ShopRemotes:WaitForChild("RF_Purchase")
+local InventoryCountChanged = ReplicatedStorage:WaitForChild("InventoryCountChanged")
+local InventoryState = require(script.Parent:WaitForChild("InventoryState"))
 
 local rarityColors = {
     Common = Color3.fromRGB(200, 200, 200),
@@ -14,7 +16,6 @@ local rarityColors = {
     Mythic = Color3.fromRGB(255, 0, 255),
 }
 
-local inventoryCount = {}
 
 local screenGui
 local list
@@ -152,7 +153,8 @@ local function populateList(catalog)
                     local result = RF_Purchase:InvokeServer({ itemId = id })
                     if result and result.ok then
                         crumbsLabel.Text = tostring(result.newBalance)
-                        inventoryCount[id] = result.newCount
+                        InventoryState.SetCount(id, result.newCount)
+                        InventoryCountChanged:Fire(id, result.newCount)
                         errorLabel.Text = "Purchased " .. (item.name or id)
                     else
                         errorLabel.Text = result and result.code or "Purchase failed"

--- a/src/server/BurstService.luau
+++ b/src/server/BurstService.luau
@@ -17,6 +17,14 @@ local ItemsConfig = loadShared("ItemsConfig")
 
 local BurstService = {}
 
+--[[
+TODO: finalize burst item handling.
+Aims: allow consumables to grant temporary aether boosts and interact
+      with growth conversions.
+Acceptance: consuming a burst item reliably applies its value and
+            interaction hooks support future features.
+]]
+
 function BurstService.Use(player, typeId)
     local cfg = ItemsConfig.Types[typeId]
     if not cfg or cfg.category ~= "burst" then

--- a/src/server/CombatService.luau
+++ b/src/server/CombatService.luau
@@ -1,5 +1,11 @@
 local CombatService = {}
 
+--[[
+TODO: implement combat validation and damage.
+Aims: enforce fire rates and apply weapon damage on hits.
+Acceptance: primary fire respects rate limits and logs hits with damage.
+]]
+
 function CombatService.FirePrimary(player, payload)
     -- TODO: validate fire rate and apply damage
     local weaponId = payload and payload.weaponId or "unknown"

--- a/src/server/CurseService.luau
+++ b/src/server/CurseService.luau
@@ -1,5 +1,11 @@
 local CurseService = {}
 
+--[[
+TODO: manage temporary player curses.
+Aims: grant, remove, and query curses while applying stat modifiers.
+Acceptance: curses stack, expire, and affect gameplay stats predictably.
+]]
+
 function CurseService.GrantCurse(player, curseId, stacks, ttl)
     -- TODO: add curse to player data
 end

--- a/src/server/DayNightService.luau
+++ b/src/server/DayNightService.luau
@@ -1,5 +1,12 @@
 local DayNightService = {}
 
+--[[
+TODO: manage global day/night cycle.
+Aims: control cycle length and broadcast time changes.
+Acceptance: cycle progresses smoothly and clients can query normalized
+            time of day.
+]]
+
 function DayNightService.SetCycleLength(seconds)
     -- TODO: set day/night cycle length
 end

--- a/src/server/EventService.luau
+++ b/src/server/EventService.luau
@@ -1,5 +1,11 @@
 local EventService = {}
 
+--[[
+TODO: orchestrate timed world events.
+Aims: schedule, start, and end events with arbitrary payloads.
+Acceptance: events can be queued and queried for active status.
+]]
+
 function EventService.Schedule(id, at, data)
     -- TODO: schedule an event
 end

--- a/src/server/FameService.luau
+++ b/src/server/FameService.luau
@@ -1,5 +1,11 @@
 local FameService = {}
 
+--[[
+TODO: implement fame progression.
+Aims: convert actions into fame and expose current totals.
+Acceptance: selling value awards fame and queries return persisted sums.
+]]
+
 function FameService.AddFameFromValue(player, value)
     -- TODO: map sell value to fame using sigmoid
     return 0

--- a/src/server/GrowthService.luau
+++ b/src/server/GrowthService.luau
@@ -1,5 +1,13 @@
 local GrowthService = {}
 
+--[[
+TODO: implement server-side producer growth system.
+Aims: register/unregister producers, advance growth over time, and
+      provide deterministic snapshots.
+Acceptance: producers tick reliably and clients receive consistent
+            growth states.
+]]
+
 function GrowthService.RegisterProducer(player, uid, seed)
     -- TODO: track producer growth state
 end

--- a/src/server/MinionService.luau
+++ b/src/server/MinionService.luau
@@ -1,5 +1,12 @@
 local MinionService = {}
 
+--[[
+TODO: drive decorative minions.
+Aims: synchronize minion spawns, reactions, and behaviors around the
+      player's base.
+Acceptance: minions appear, celebrate on sales, and tick autonomously.
+]]
+
 function MinionService.SyncForPlayer(player)
     -- TODO: spawn or update minions around base
 end

--- a/src/server/WeaponService.luau
+++ b/src/server/WeaponService.luau
@@ -1,5 +1,11 @@
 local WeaponService = {}
 
+--[[
+TODO: handle weapon equipment and retrieval.
+Aims: equip weapons per player and expose current loadout.
+Acceptance: equipping returns success and queries reflect state.
+]]
+
 function WeaponService.EquipWeapon(player, weaponId)
     -- TODO: equip weapon for player
     return false, "NOT_IMPLEMENTED"

--- a/src/server/WorldGenService.luau
+++ b/src/server/WorldGenService.luau
@@ -1,5 +1,11 @@
 local WorldGenService = {}
 
+--[[
+TODO: procedural island generation.
+Aims: spawn/despawn islands from prefabs and expose active listings.
+Acceptance: generated islands track by id and can be queried or removed.
+]]
+
 function WorldGenService.SpawnIsland(spec)
     -- TODO: assemble island from prefabs
     return 0


### PR DESCRIPTION
## Summary
- centralize inventory counts via InventoryState and update HeldItemController, InventoryUI, ShopUI
- document future work with TODO blocks across stub services

## Testing
- `rojo build -o "skyhunters.rbxlx"` *(fails: Rojo project referred to a file using $path that could not be turned into a Roblox Instance)*
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a1292879e883278852ab7c728fae1b