### PR TITLE
feat: sync inventory and improve placement

### DIFF
--- a/src/client/HeldItemController.luau
+++ b/src/client/HeldItemController.luau
@@ -10,12 +10,10 @@ local PlacementRejected = ReplicatedStorage:WaitForChild("PlacementRejected")
 
 local ModelUtils = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("ModelUtils"))
 local EquippedUI = require(script.Parent:WaitForChild("EquippedUI"))
-local InventoryCountChanged = ReplicatedStorage:WaitForChild("InventoryCountChanged")
 local ItemsConfig = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("ItemsConfig"))
 local InventoryState = require(script.Parent:WaitForChild("InventoryState"))
 
 local player = Players.LocalPlayer
-local mouse = player:GetMouse()
 
 type ItemDef = {
     id: string,
@@ -35,21 +33,21 @@ local placingItemId: string? = nil
 local heldModel: Instance? = nil
 local ghostModel: Instance? = nil
 local currentTemplate: Instance? = nil
-local lastMouseHit: CFrame? = nil
-local lastMouseOnPlatform = false
 local currentItemDef: ItemDef? = nil
 local currentMode: ("build" | "equip")? = nil
 
 local savedCameraMode: Enum.CameraMode? = nil
 local savedMinZoom: number? = nil
 local savedMaxZoom: number? = nil
+local updateConn: RBXScriptConnection? = nil
+local countConn: RBXScriptConnection? = nil
+local canPlace = false
 
 local GRID = 1
 local snapEnabled = false
 local currentYaw = 0
-local lastPlace = 0
-
 local exitButton
+local hintLabel
 do
     local gui = Instance.new("ScreenGui")
     gui.Name = "PlacementGui"
@@ -63,6 +61,14 @@ do
     exitButton.AnchorPoint = Vector2.new(1, 0)
     exitButton.Visible = false
     exitButton.Parent = gui
+
+    hintLabel = Instance.new("TextLabel")
+    hintLabel.Size = UDim2.new(1, 0, 0, 24)
+    hintLabel.Position = UDim2.new(0, 0, 1, -28)
+    hintLabel.BackgroundTransparency = 1
+    hintLabel.TextColor3 = Color3.new(1, 1, 1)
+    hintLabel.Text = ""
+    hintLabel.Parent = gui
 end
 
 local function getModel(modelName: string): Instance
@@ -101,6 +107,11 @@ local plotBounds = {
     max = Vector3.new(50, 0, 50),
 }
 
+local plotCenterX = 0
+local plotCenterZ = 0
+local halfSizeX = 50
+local halfSizeZ = 50
+
 local plotPlatform: Instance? = nil
 
 -- Optional: rename to your real platform object (Part or Model)
@@ -113,6 +124,10 @@ local function updatePlotBounds()
         local cf, size = platform:GetBoundingBox()
         plotBounds.min = cf.Position - size / 2
         plotBounds.max = cf.Position + size / 2
+        plotCenterX = (plotBounds.min.X + plotBounds.max.X) / 2
+        plotCenterZ = (plotBounds.min.Z + plotBounds.max.Z) / 2
+        halfSizeX = (plotBounds.max.X - plotBounds.min.X) / 2
+        halfSizeZ = (plotBounds.max.Z - plotBounds.min.Z) / 2
         return
     end
     if platform and platform:IsA("BasePart") then
@@ -120,11 +135,19 @@ local function updatePlotBounds()
         local size = platform.Size
         plotBounds.min = cf.Position - size / 2
         plotBounds.max = cf.Position + size / 2
+        plotCenterX = (plotBounds.min.X + plotBounds.max.X) / 2
+        plotCenterZ = (plotBounds.min.Z + plotBounds.max.Z) / 2
+        halfSizeX = (plotBounds.max.X - plotBounds.min.X) / 2
+        halfSizeZ = (plotBounds.max.Z - plotBounds.min.Z) / 2
         return
     end
     -- Fallback if platform is missing
     plotBounds.min = Vector3.new(-50, 0, -50)
     plotBounds.max = Vector3.new(50, 0, 50)
+    plotCenterX = 0
+    plotCenterZ = 0
+    halfSizeX = 50
+    halfSizeZ = 50
     plotPlatform = nil
 end
 
@@ -174,26 +197,28 @@ local function spawnGhost(asset: Instance): Instance
     return g
 end
 
+local function showToast(msg: string)
+    pcall(function()
+        game:GetService("StarterGui"):SetCore("SendNotification", { Title = "Skyhunters", Text = msg, Duration = 2 })
+    end)
+end
+
+local function isPlayerInPlotXZ(): boolean
+    local character = player.Character
+    local hrp = character and character:FindFirstChild("HumanoidRootPart")
+    if not hrp then
+        return false
+    end
+    local p = hrp.Position
+    local dx = math.abs(p.X - plotCenterX)
+    local dz = math.abs(p.Z - plotCenterZ)
+    return dx <= halfSizeX and dz <= halfSizeZ
+end
+
 local function snap(v: number, step: number): number
     return math.floor((v + step / 2) / step) * step
 end
 
-local function updateGhostAt(mouseHit: CFrame)
-    if not ghostModel then
-        return
-    end
-    local pos = mouseHit.Position
-    local yTop = plotBounds.max.Y
-    local useSnap = snapEnabled and GRID > 0 and not (UserInputService:IsKeyDown(Enum.KeyCode.LeftShift) or UserInputService:IsKeyDown(Enum.KeyCode.RightShift))
-    local basePos
-    if useSnap then
-        basePos = Vector3.new(snap(pos.X, GRID), yTop, snap(pos.Z, GRID))
-    else
-        basePos = Vector3.new(pos.X, yTop, pos.Z)
-    end
-    local cf = CFrame.new(basePos) * CFrame.Angles(0, currentYaw, 0)
-    pivotTo(cf, ghostModel)
-end
 
 local function attachCarry(character: Model, asset: Instance, socketName: string, offset: CFrame?)
     if heldModel then heldModel:Destroy() end
@@ -249,6 +274,14 @@ local function cancelPlacement()
     currentTemplate = nil
     currentItemDef = nil
     currentMode = nil
+    if updateConn then
+        updateConn:Disconnect()
+        updateConn = nil
+    end
+    if countConn then
+        countConn:Disconnect()
+        countConn = nil
+    end
     if heldModel then
         heldModel:Destroy()
         heldModel = nil
@@ -257,8 +290,7 @@ local function cancelPlacement()
         ghostModel:Destroy()
         ghostModel = nil
     end
-    lastMouseHit = nil
-    lastMouseOnPlatform = false
+    hintLabel.Text = ""
     exitButton.Visible = false
     if savedCameraMode then
         player.CameraMode = savedCameraMode
@@ -279,24 +311,14 @@ exitButton.Activated:Connect(function()
     HeldItemController.Stop()
 end)
 
-RunService.Heartbeat:Connect(function()
-    if currentMode ~= "build" then
-        return
-    end
-    local character = player.Character
-    local hrp = character and character:FindFirstChild("HumanoidRootPart")
-    if not hrp then
-        return
-    end
-    local pos = hrp.Position
-    local within = ModelUtils.insideHorizontalBounds(pos, plotBounds)
-    if not within then
-        HeldItemController.Stop()
-    end
-end)
 
 function HeldItemController.Start(itemDef: ItemDef, mode: "build" | "equip")
     if currentItemDef then
+        return
+    end
+    InventoryState.InitOnce()
+    if InventoryState.GetCount(itemDef.id) <= 0 then
+        showToast("Out of items")
         return
     end
     currentItemDef = itemDef
@@ -304,17 +326,15 @@ function HeldItemController.Start(itemDef: ItemDef, mode: "build" | "equip")
     savedCameraMode = player.CameraMode
     savedMinZoom = player.CameraMinZoomDistance
     savedMaxZoom = player.CameraMaxZoomDistance
+    local character = player.Character or player.CharacterAdded:Wait()
     if mode == "build" then
         placingItemId = itemDef.id
         StartHolding:FireServer(itemDef.id)
         currentTemplate = getModel(itemDef.model)
-        local character = player.Character or player.CharacterAdded:Wait()
         attachCarry(character, currentTemplate, itemDef.weldTo or "Head", itemDef.carryOffset)
-        lastMouseHit = nil
-        lastMouseOnPlatform = false
+        spawnGhost(currentTemplate)
         exitButton.Visible = true
     elseif mode == "equip" then
-        local character = player.Character or player.CharacterAdded:Wait()
         local asset = getModel(itemDef.model)
         attachCarry(character, asset, itemDef.weldTo or "RightHand", itemDef.carryOffset)
         exitButton.Visible = true
@@ -333,6 +353,42 @@ function HeldItemController.Start(itemDef: ItemDef, mode: "build" | "equip")
     end
     local count = InventoryState.GetCount(itemDef.id)
     EquippedUI.Show(itemDef.icon or "", itemDef.name or "", count)
+    countConn = InventoryState.OnItemCountChanged:Connect(function(id, newCount)
+        if currentItemDef and id == currentItemDef.id then
+            EquippedUI.Update(newCount)
+            if newCount <= 0 then
+                HeldItemController.Stop()
+            end
+        end
+    end)
+    updateConn = RunService:BindToRenderStep("Placement_Update", Enum.RenderPriority.First.Value + 1, function()
+        if currentMode ~= "build" or not currentTemplate or not ghostModel then
+            return
+        end
+        local camera = workspace.CurrentCamera
+        local mousePos = UserInputService:GetMouseLocation()
+        local ray = camera:ViewportPointToRay(mousePos.X, mousePos.Y)
+        local params = RaycastParams.new()
+        params.FilterType = Enum.RaycastFilterType.Blacklist
+        params.FilterDescendantsInstances = { character }
+        local result = workspace:Raycast(ray.Origin, ray.Direction * 500, params)
+        local hitPos
+        if result then
+            hitPos = result.Position
+        else
+            local planeY = plotBounds.max.Y
+            local t = (planeY - ray.Origin.Y) / ray.Direction.Y
+            hitPos = ray.Origin + ray.Direction * t
+        end
+        local basePos = Vector3.new(hitPos.X, plotBounds.max.Y, hitPos.Z)
+        if snapEnabled and GRID > 0 and not (UserInputService:IsKeyDown(Enum.KeyCode.LeftShift) or UserInputService:IsKeyDown(Enum.KeyCode.RightShift)) then
+            basePos = Vector3.new(snap(basePos.X, GRID), plotBounds.max.Y, snap(basePos.Z, GRID))
+        end
+        local cf = CFrame.new(basePos) * CFrame.Angles(0, currentYaw, 0)
+        pivotTo(cf, ghostModel)
+        canPlace = isPlayerInPlotXZ()
+        hintLabel.Text = canPlace and "" or "Step onto your plot to place"
+    end)
 end
 
 HeldItemController.Stop = cancelPlacement
@@ -377,11 +433,9 @@ local function tryPlace()
     if not placingItemId or not ghostModel or InventoryState.GetCount(placingItemId) <= 0 then
         return
     end
-    local now = tick()
-    if now - lastPlace < 0.2 then
+    if not canPlace then
         return
     end
-    lastPlace = now
     local cf
     if ghostModel:IsA("Model") then
         cf = ghostModel:GetPivot()
@@ -399,44 +453,15 @@ ConfirmPlacement.OnClientEvent:Connect(function(ok, payload)
         ghostModel:Destroy()
         ghostModel = nil
     end
-    local newCount = payload and payload.remaining or 0
-    InventoryState.SetCount(placingItemId, newCount)
-    InventoryCountChanged:Fire(placingItemId, newCount)
-    if newCount <= 0 then
-        HeldItemController.Stop()
-        return
-    end
-    EquippedUI.Update(newCount)
-    if lastMouseHit and lastMouseOnPlatform and currentTemplate then
+    if currentTemplate then
         spawnGhost(currentTemplate)
-        updateGhostAt(lastMouseHit)
     end
-    -- else: wait for next mouse.Move to re-enter bounds before recreating the ghost
 end)
 
 PlacementRejected.OnClientEvent:Connect(function()
     -- keep ghost so player can adjust
 end)
 
-mouse.Move:Connect(function()
-    if currentMode ~= "build" or not currentTemplate then return end
-
-    lastMouseHit = mouse.Hit
-    local pos = lastMouseHit.Position
-    local onPlot = ModelUtils.insideHorizontalBounds(pos, plotBounds)
-    if onPlot then
-        if not ghostModel then
-            spawnGhost(currentTemplate)
-        end
-        updateGhostAt(lastMouseHit)
-    else
-        if ghostModel then
-            ghostModel:Destroy()
-            ghostModel = nil
-        end
-    end
-    lastMouseOnPlatform = onPlot
-end)
 
 UserInputService.InputBegan:Connect(function(input, processed)
     if processed then
@@ -450,14 +475,8 @@ UserInputService.InputBegan:Connect(function(input, processed)
         else
             currentYaw += math.rad(15)
         end
-        if lastMouseHit then
-            updateGhostAt(lastMouseHit)
-        end
     elseif currentMode == "build" and input.KeyCode == Enum.KeyCode.G then
         snapEnabled = not snapEnabled
-        if lastMouseHit then
-            updateGhostAt(lastMouseHit)
-        end
     elseif input.KeyCode == Enum.KeyCode.X then
 
         HeldItemController.Stop()

--- a/src/client/InventoryState.luau
+++ b/src/client/InventoryState.luau
@@ -1,13 +1,60 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
 local InventoryState = {}
 
-local counts = {}
+local counts: { [string]: number } = {}
+local crumbs = 0
+local initialized = false
 
-function InventoryState.SetCount(uid: string, count: number)
-    counts[uid] = count
+local countChanged = Instance.new("BindableEvent")
+local crumbsChanged = Instance.new("BindableEvent")
+
+local function showError(msg)
+    warn("[InventoryState] " .. msg)
 end
 
-function InventoryState.GetCount(uid: string): number
-    return counts[uid] or 0
+function InventoryState.InitOnce()
+    if initialized then
+        return
+    end
+    initialized = true
+    local remotes = ReplicatedStorage:WaitForChild("Remotes")
+    local folder = remotes:WaitForChild("Inventory")
+    local rfSnapshot = folder:WaitForChild("RF_GetInventorySnapshot") :: RemoteFunction
+    local rePush = folder:WaitForChild("RE_InventoryPush") :: RemoteEvent
+    local snapshot = rfSnapshot:InvokeServer()
+    if typeof(snapshot) == "table" then
+        counts = snapshot.inventory or {}
+        crumbs = snapshot.crumbs or 0
+        crumbsChanged:Fire(crumbs)
+    else
+        showError("snapshot failed")
+    end
+    rePush.OnClientEvent:Connect(function(payload)
+        if typeof(payload) ~= "table" then
+            return
+        end
+        local id = payload.id
+        local newCount = payload.newCount or 0
+        counts[id] = newCount
+        countChanged:Fire(id, newCount)
+    end)
 end
+
+function InventoryState.GetCount(id: string): number
+    return counts[id] or 0
+end
+
+function InventoryState.GetCrumbs(): number
+    return crumbs
+end
+
+function InventoryState.SetCrumbs(newAmount: number)
+    crumbs = newAmount
+    crumbsChanged:Fire(crumbs)
+end
+
+InventoryState.OnItemCountChanged = countChanged.Event
+InventoryState.OnCrumbsChanged = crumbsChanged.Event
 
 return InventoryState

--- a/src/client/InventoryUI.luau
+++ b/src/client/InventoryUI.luau
@@ -4,12 +4,6 @@ local RunService = game:GetService("RunService")
 local TweenService = game:GetService("TweenService")
 
 local InventoryConfig = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("InventoryConfig"))
-local CountChangedEvent = ReplicatedStorage:FindFirstChild("InventoryCountChanged")
-if not CountChangedEvent then
-    CountChangedEvent = Instance.new("BindableEvent")
-    CountChangedEvent.Name = "InventoryCountChanged"
-    CountChangedEvent.Parent = ReplicatedStorage
-end
 local HeldItemController = require(script.Parent:WaitForChild("HeldItemController"))
 local InventoryState = require(script.Parent:WaitForChild("InventoryState"))
 
@@ -45,6 +39,12 @@ local function createCell()
         end
         local item = itemLookup[uid]
         if item then
+            if InventoryState.GetCount(item.uid) <= 0 then
+                pcall(function()
+                    game:GetService("StarterGui"):SetCore("SendNotification", { Title = "Skyhunters", Text = "Out of items", Duration = 2 })
+                end)
+                return
+            end
             local current, mode = HeldItemController.GetCurrent()
             if current and current.id == item.uid and mode == "build" then
                 return
@@ -83,7 +83,7 @@ local function renderGrid()
     end
 end
 
-CountChangedEvent.Event:Connect(function(uid, newCount)
+InventoryState.OnItemCountChanged:Connect(function(uid, newCount)
     local item = itemLookup[uid]
     if item then
         item.count = newCount
@@ -97,7 +97,6 @@ CountChangedEvent.Event:Connect(function(uid, newCount)
             itemLookup[uid] = nil
         end
     end
-    InventoryState.SetCount(uid, newCount)
     renderGrid()
 end)
 
@@ -109,9 +108,9 @@ local function fetchPage(reset)
     end
     local page, newCursor = RF_Fetch:InvokeServer(currentCategory, currentSearch, nextCursor)
     for _, item in ipairs(page) do
+        item.count = InventoryState.GetCount(item.uid)
         table.insert(items, item)
         itemLookup[item.uid] = item
-        InventoryState.SetCount(item.uid, item.count)
     end
     nextCursor = newCursor
 end
@@ -122,6 +121,7 @@ local function refresh()
 end
 
 function InventoryUI.Init()
+    InventoryState.InitOnce()
     local playerGui = localPlayer:WaitForChild("PlayerGui")
     local screenGui = Instance.new("ScreenGui")
     screenGui.Name = "InventoryGUI"

--- a/src/client/ShopUI.luau
+++ b/src/client/ShopUI.luau
@@ -5,7 +5,6 @@ local localPlayer = Players.LocalPlayer
 
 local RF_FetchShopSnapshot = ReplicatedStorage:WaitForChild("ShopRemotes"):WaitForChild("RF_FetchShopSnapshot")
 local RF_Purchase = ReplicatedStorage.ShopRemotes:WaitForChild("RF_Purchase")
-local InventoryCountChanged = ReplicatedStorage:WaitForChild("InventoryCountChanged")
 local InventoryState = require(script.Parent:WaitForChild("InventoryState"))
 
 local rarityColors = {
@@ -96,6 +95,9 @@ local function createGui()
     list = listFrame
     errorLabel = err
     crumbsLabel = crumb
+    InventoryState.OnCrumbsChanged:Connect(function(amount)
+        crumbsLabel.Text = tostring(amount)
+    end)
     return gui
 end
 
@@ -149,12 +151,20 @@ local function populateList(catalog)
                 buyButton.Text = "Buy"
                 buyButton.Parent = entry
 
+                local function updateBuyState()
+                    buyButton.Active = InventoryState.GetCrumbs() >= (item.displayPrice or 0)
+                    buyButton.AutoButtonColor = buyButton.Active
+                end
+                updateBuyState()
+                InventoryState.OnCrumbsChanged:Connect(updateBuyState)
+
                 buyButton.MouseButton1Click:Connect(function()
+                    if not buyButton.Active then
+                        return
+                    end
                     local result = RF_Purchase:InvokeServer({ itemId = id })
                     if result and result.ok then
-                        crumbsLabel.Text = tostring(result.newBalance)
-                        InventoryState.SetCount(id, result.newCount)
-                        InventoryCountChanged:Fire(id, result.newCount)
+                        InventoryState.SetCrumbs(result.newBalance or InventoryState.GetCrumbs())
                         errorLabel.Text = "Purchased " .. (item.name or id)
                     else
                         errorLabel.Text = result and result.code or "Purchase failed"
@@ -180,11 +190,13 @@ local function open()
         errorLabel.Text = "Failed to load catalog"
         return
     end
-    crumbsLabel.Text = tostring(snapshot.balance or 0)
+    InventoryState.SetCrumbs(snapshot.balance or 0)
+    crumbsLabel.Text = tostring(InventoryState.GetCrumbs())
     populateList(snapshot.catalog)
 end
 
 function ShopUI.Init()
+    InventoryState.InitOnce()
     createGui()
     local prompt = workspace:WaitForChild("ShopNPC"):WaitForChild("ProximityPrompt")
     prompt.Triggered:Connect(open)

--- a/src/server/InventoryRemotes.server.luau
+++ b/src/server/InventoryRemotes.server.luau
@@ -1,0 +1,34 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
+
+local remotesFolder = ReplicatedStorage:FindFirstChild("Remotes")
+if not remotesFolder then
+    remotesFolder = Instance.new("Folder")
+    remotesFolder.Name = "Remotes"
+    remotesFolder.Parent = ReplicatedStorage
+end
+
+local inventoryFolder = remotesFolder:FindFirstChild("Inventory")
+if not inventoryFolder then
+    inventoryFolder = Instance.new("Folder")
+    inventoryFolder.Name = "Inventory"
+    inventoryFolder.Parent = remotesFolder
+end
+
+local rfSnapshot = Instance.new("RemoteFunction")
+rfSnapshot.Name = "RF_GetInventorySnapshot"
+rfSnapshot.Parent = inventoryFolder
+rfSnapshot.OnServerInvoke = function(player)
+    local data = PlayerManager.GetPlayerData(player)
+    local invCopy = {}
+    for id, count in pairs(data.inventory or {}) do
+        invCopy[id] = count
+    end
+    return { inventory = invCopy, crumbs = data.crumbs or 0 }
+end
+
+local rePush = Instance.new("RemoteEvent")
+rePush.Name = "RE_InventoryPush"
+rePush.Parent = inventoryFolder
+
+return nil

--- a/src/server/InventoryService.luau
+++ b/src/server/InventoryService.luau
@@ -1,4 +1,23 @@
 local PlayerManager = require(script.Parent:WaitForChild("PlayerManager"))
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local function getPushEvent()
+    local ok, folder = pcall(function()
+        return ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("Inventory"):WaitForChild("RE_InventoryPush")
+    end)
+    if ok then
+        return folder
+    end
+    return nil
+end
+
+local function pushCount(player, itemId)
+    local ev = getPushEvent()
+    if not ev then
+        return
+    end
+    ev:FireClient(player, { id = itemId, newCount = InventoryService.GetCount(player, itemId) })
+end
 
 local function loadShared(name)
     local ok, ReplicatedStorage = pcall(function()
@@ -19,6 +38,7 @@ function InventoryService.Add(player, typeId, qty)
     qty = qty or 1
     local data = PlayerManager.GetPlayerData(player)
     data.inventory[typeId] = (data.inventory[typeId] or 0) + qty
+    pushCount(player, typeId)
     return true
 end
 
@@ -33,6 +53,7 @@ function InventoryService.Consume(player, typeId, qty)
     if data.inventory[typeId] <= 0 then
         data.inventory[typeId] = nil
     end
+    pushCount(player, typeId)
     return true
 end
 


### PR DESCRIPTION
## Summary
- add inventory snapshot and push remotes with server-side count broadcasting
- centralize client inventory/crumb tracking and live updates
- allow equipping anywhere with ghost tracking player & cursor and XZ plot gating
- use shared inventory state across inventory & shop UIs

## Testing
- `lua spec/economy_spec.lua`
- `lua spec/inventory_spec.lua`
- `lua spec/ghost_preview_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a136c593b08327a17e2a1f9e7e122a