### PR TITLE
Add visual pooling, loom complexity logging, and harvest locking

### DIFF
--- a/src/client/growth/GrowthVisualizer.luau
+++ b/src/client/growth/GrowthVisualizer.luau
@@ -9,14 +9,60 @@ local LoomConfigs = require("looms/LoomConfigs")
 local GrowthProfiles = require("looms/GrowthProfiles")
 
 -- Simplified pool structure used for tests. Real implementation would reuse
--- Instances. Here we just keep numeric data.
+-- Instances. Here we just keep numeric data. Pooling allows early perf
+-- measurements without allocating every render.
 local visuals = {}
+local segmentPools = {}
+local tipDecoPool = {}
+local tipDecos = {}
+
+local function acquireSegmentBuffer(n)
+    local pool = segmentPools[n]
+    if pool and #pool > 0 then
+        local buf = pool[#pool]
+        pool[#pool] = nil
+        return buf
+    end
+    local buf = {}
+    for i = 1, n do
+        buf[i] = 0
+    end
+    return buf
+end
+
+local function releaseSegmentBuffer(n, buf)
+    for i = 1, n do
+        buf[i] = nil
+    end
+    local pool = segmentPools[n]
+    if not pool then
+        pool = {}
+        segmentPools[n] = pool
+    end
+    pool[#pool + 1] = buf
+end
+
+local function acquireTipDeco()
+    local deco = tipDecoPool[#tipDecoPool]
+    if deco then
+        tipDecoPool[#tipDecoPool] = nil
+        return deco
+    end
+    return {}
+end
+
+local function releaseTipDeco(deco)
+    for k in pairs(deco) do
+        deco[k] = nil
+    end
+    tipDecoPool[#tipDecoPool + 1] = deco
+end
 
 local function computeSegmentFill(N, g)
     local totalProgress = (g/100) * N
     local full = math.floor(totalProgress)
     local partial = totalProgress - full
-    local result = {}
+    local result = acquireSegmentBuffer(N)
     for i = 1, N do
         if i <= full then
             result[i] = 1
@@ -33,11 +79,30 @@ function GrowthVisualizer.Render(container, loomState)
     local config = LoomConfigs[loomState.configId]
     if not config then return end
     local segCount = loomState.overrides and loomState.overrides.segmentCount or config.growthDefaults.segmentCount
+
+    local existing = visuals[loomState.loomUid]
+    if existing then
+        releaseSegmentBuffer(#existing, existing)
+    end
+
     visuals[loomState.loomUid] = computeSegmentFill(segCount, loomState.g)
+
+    if not tipDecos[loomState.loomUid] then
+        tipDecos[loomState.loomUid] = acquireTipDeco()
+    end
 end
 
 function GrowthVisualizer.Release(container, loomUid)
-    visuals[loomUid] = nil
+    local visual = visuals[loomUid]
+    if visual then
+        releaseSegmentBuffer(#visual, visual)
+        visuals[loomUid] = nil
+    end
+    local deco = tipDecos[loomUid]
+    if deco then
+        releaseTipDeco(deco)
+        tipDecos[loomUid] = nil
+    end
 end
 
 function GrowthVisualizer._getVisualState(loomUid)

--- a/src/server/GrowthService.luau
+++ b/src/server/GrowthService.luau
@@ -51,6 +51,11 @@ function GrowthService.RegisterLoom(player, configId, rarity, overrides, baseSee
         overrides = overrides,
         completed = false,
     }
+    local complexity = computeComplexity(config, overrides)
+    local rarityMul = Rarity.GetGrowthMultiplier(rarity)
+    local rate = BASE_RATE * rarityMul / complexity
+    local totalTime = 100 / rate
+    print(string.format("GrowthService.RegisterLoom uid=%s complexity=%.2f rate=%.4f time=%.2f", uid, complexity, rate, totalTime))
     return uid
 end
 

--- a/src/server/WeaverService.luau
+++ b/src/server/WeaverService.luau
@@ -6,6 +6,7 @@
 local WeaverService = {}
 
 local looms = {}
+local harvestLocks = {}
 
 function WeaverService.OnNodesEligible(loomUid, eligible)
     local state = looms[loomUid]
@@ -29,14 +30,29 @@ function WeaverService.ActivateSome(loomUid)
 end
 
 function WeaverService.TryHarvest(player, loomUid, nodeId)
+    local lock = harvestLocks[loomUid]
+    if not lock then
+        lock = {}
+        harvestLocks[loomUid] = lock
+    end
+    if lock[nodeId] then
+        return false, "duplicate_harvest"
+    end
+    lock[nodeId] = true
+
     local state = looms[loomUid]
-    if not state then return false, "unknown_loom" end
+    if not state then
+        lock[nodeId] = nil
+        return false, "unknown_loom"
+    end
     for i, id in ipairs(state.occupied) do
         if id == nodeId then
             table.remove(state.occupied, i)
+            lock[nodeId] = nil
             return true, nil
         end
     end
+    lock[nodeId] = nil
     return false, "node_not_occupied"
 end
 


### PR DESCRIPTION
## Summary
- add segment and tip decoration pooling to GrowthVisualizer to reuse buffers
- log loom complexity, growth rate, and total time at creation in GrowthService
- prevent duplicate node harvests with lock in WeaverService

## Testing
- `lua spec/economy_spec.lua`
- `lua spec/loom_growth_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a1993bb8a483279f0f02e57ee44c90