### PR TITLE
Use instance-based module resolution for LoomDesigner plugin

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -2,31 +2,25 @@
 -- LoomDesigner plugin. Manages a tiny state object representing the designer
 -- selections and can export configs to a Lua file.
 
-local ReplicatedStorage
-local GrowthVisualizer
-local LoomConfigs
-if rawget(_G, "game") and game.GetService then
-        ReplicatedStorage = game:GetService("ReplicatedStorage")
-        GrowthVisualizer = require(ReplicatedStorage.growth.GrowthVisualizer)
-        LoomConfigs = require(ReplicatedStorage.looms.LoomConfigs)
-else
-        ReplicatedStorage = {}
-        GrowthVisualizer = require("growth/GrowthVisualizer")
-        LoomConfigs = require("looms/LoomConfigs")
-end
+local RequireUtil = require(script.Parent.RequireUtil)
 
-local VisualScene
-local ModelResolver
-local SegmentBuilder
-if script and script.Parent then
-        VisualScene = require(script.Parent.VisualScene)
-        ModelResolver = require(script.Parent.ModelResolver)
-        SegmentBuilder = require(script.Parent.SegmentBuilder)
-else
-        VisualScene = require("LoomDesigner/VisualScene")
-        ModelResolver = require("LoomDesigner/ModelResolver")
-        SegmentBuilder = require("LoomDesigner/SegmentBuilder")
-end
+-- Prefer game modules (ReplicatedStorage), fallback to copies shipped with the plugin
+local GrowthVisualizer = RequireUtil.fromReplicatedStorage({"growth","GrowthVisualizer"})
+    or RequireUtil.fromRelative(script.Parent.Parent, {"growth","GrowthVisualizer"})
+GrowthVisualizer = RequireUtil.must(GrowthVisualizer, "growth/GrowthVisualizer")
+
+local LoomConfigs = RequireUtil.fromReplicatedStorage({"looms","LoomConfigs"})
+    or RequireUtil.fromRelative(script.Parent.Parent, {"looms","LoomConfigs"})
+LoomConfigs = RequireUtil.must(LoomConfigs, "looms/LoomConfigs")
+
+local VisualScene = RequireUtil.fromRelative(script.Parent, {"VisualScene"})
+VisualScene = RequireUtil.must(VisualScene, "LoomDesigner/VisualScene")
+
+local ModelResolver = RequireUtil.fromRelative(script.Parent, {"ModelResolver"})
+ModelResolver = RequireUtil.must(ModelResolver, "LoomDesigner/ModelResolver")
+
+local SegmentBuilder = RequireUtil.fromRelative(script.Parent, {"SegmentBuilder"})
+SegmentBuilder = RequireUtil.must(SegmentBuilder, "LoomDesigner/SegmentBuilder")
 
 local LoomDesigner = {}
 
@@ -45,7 +39,7 @@ local function hashToInt(s)
         s = tostring(s)
         local h = 2166136261
         for i = 1, #s do
-                h = (h ~ string.byte(s, i)) * 16777619 % 2^32
+                h = (bit32.bxor(h, string.byte(s, i))) * 16777619 % 2^32
         end
         return h % 2147483647
 end

--- a/plugin/LoomDesigner/ModelResolver.lua
+++ b/plugin/LoomDesigner/ModelResolver.lua
@@ -1,4 +1,5 @@
 --!strict
+local RequireUtil = require(script.Parent.RequireUtil)
 local ReplicatedStorage
 if rawget(_G, "game") and game.GetService then
     ReplicatedStorage = game:GetService("ReplicatedStorage")

--- a/plugin/LoomDesigner/Plugin.plugin.lua
+++ b/plugin/LoomDesigner/Plugin.plugin.lua
@@ -1,4 +1,5 @@
 --!strict
+local RequireUtil = require(script.Parent.RequireUtil)
 local UI = require(script.Parent.UI)
 local LoomDesigner = require(script.Parent.Main)
 

--- a/plugin/LoomDesigner/RequireUtil.lua
+++ b/plugin/LoomDesigner/RequireUtil.lua
@@ -1,0 +1,36 @@
+--!strict
+local RequireUtil = {}
+
+local function descend(root: Instance?, path: {string}): Instance?
+    local node = root
+    for _, name in ipairs(path) do
+        if not node then return nil end
+        node = node:FindFirstChild(name)
+    end
+    return node
+end
+
+function RequireUtil.fromReplicatedStorage(path: {string})
+    local ok, RS = pcall(game.GetService, game, "ReplicatedStorage")
+    if not ok or not RS then return nil end
+    local inst = descend(RS, path)
+    if inst and inst:IsA("ModuleScript") then
+        return require(inst)
+    end
+    return nil
+end
+
+function RequireUtil.fromRelative(anchor: Instance, path: {string})
+    local inst = descend(anchor, path)
+    if inst and inst:IsA("ModuleScript") then
+        return require(inst)
+    end
+    return nil
+end
+
+function RequireUtil.must(mod, name: string)
+    if not mod then error(("[LoomDesigner] Could not resolve module: %s"):format(name), 2) end
+    return mod
+end
+
+return RequireUtil

--- a/plugin/LoomDesigner/SegmentBuilder.lua
+++ b/plugin/LoomDesigner/SegmentBuilder.lua
@@ -1,4 +1,5 @@
 --!strict
+local RequireUtil = require(script.Parent.RequireUtil)
 local SegmentBuilder = {}
 
 -- Builds a single segment Instance according to materialization mode.

--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -1,4 +1,5 @@
 --!strict
+local RequireUtil = require(script.Parent.RequireUtil)
 local LoomDesigner = require(script.Parent.Main)
 
 local UI = {}

--- a/plugin/LoomDesigner/VisualScene.lua
+++ b/plugin/LoomDesigner/VisualScene.lua
@@ -1,4 +1,5 @@
 --!strict
+local RequireUtil = require(script.Parent.RequireUtil)
 local VisualScene = {}
 
 local previewModel: Model? = nil

--- a/src/client/growth/GrowthVisualizer.luau
+++ b/src/client/growth/GrowthVisualizer.luau
@@ -5,14 +5,37 @@
 
 local LoomConfigs
 local GrowthProfiles
-if rawget(_G, "game") and game.ReplicatedStorage then
-    LoomConfigs = require(game.ReplicatedStorage.looms.LoomConfigs)
-    GrowthProfiles = require(game.ReplicatedStorage.growth.GrowthProfiles)
-else
-    LoomConfigs = require("looms/LoomConfigs")
-    GrowthProfiles = require("looms/GrowthProfiles")
+do
+    local ok, RS = pcall(game.GetService, game, "ReplicatedStorage")
+    if ok and RS then
+        LoomConfigs = LoomConfigs or (RS:FindFirstChild("looms") and RS.looms:FindFirstChild("LoomConfigs") and require(RS.looms.LoomConfigs))
+        GrowthProfiles = GrowthProfiles or (RS:FindFirstChild("growth") and RS.growth:FindFirstChild("GrowthProfiles") and require(RS.growth.GrowthProfiles))
+    end
+    if not LoomConfigs then
+        local root = script and script:FindFirstAncestor("LoomDesigner")
+        if root then
+            local lc = root:FindFirstChild("looms")
+            if lc and lc:FindFirstChild("LoomConfigs") then LoomConfigs = require(lc.LoomConfigs) end
+        end
+    end
+    if not GrowthProfiles then
+        local root = script and script:FindFirstAncestor("LoomDesigner")
+        if root then
+            local gr = root:FindFirstChild("growth")
+            if gr and gr:FindFirstChild("GrowthProfiles") then GrowthProfiles = require(gr.GrowthProfiles) end
+        end
+    end
+    if not LoomConfigs then error("[GrowthVisualizer] Could not resolve LoomConfigs") end
+    if not GrowthProfiles then error("[GrowthVisualizer] Could not resolve GrowthProfiles") end
 end
-local SegmentBuilder = require("LoomDesigner/SegmentBuilder")
+
+local SegmentBuilder
+do
+    local root = script and script:FindFirstAncestor("LoomDesigner")
+    if root and root:FindFirstChild("SegmentBuilder") then
+        SegmentBuilder = require(root.SegmentBuilder)
+    end
+end
 local function clamp(v, mn, mx)
     if v < mn then return mn end
     if v > mx then return mx end
@@ -172,7 +195,7 @@ function GrowthVisualizer.Render(container, loomState)
     local currentCF = CFrame.new(0,0,0)
     for i, seg in ipairs(segments) do
         if seg.fill > 0 then
-            local inst = SegmentBuilder.Build({
+            local inst = SegmentBuilder and SegmentBuilder.Build({
                 mode = matOverrides.mode or "Model",
                 depth = i-1,
                 isTerminal = (i == segCount),


### PR DESCRIPTION
## Summary
- add shared `RequireUtil` helper for resolving modules
- refactor LoomDesigner plugin to resolve growth and loom modules via instances
- switch GrowthVisualizer to instance-based requires and keep bit32-based hashing

## Testing
- `rojo build -o "skyhunters.rbxlx"`
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a2c525896c8327bc0033ac5be601c9