### PR TITLE
feat: spawn parts in LoomDesigner preview

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -19,9 +19,6 @@ VisualScene = RequireUtil.must(VisualScene, "LoomDesigner/VisualScene")
 local ModelResolver = RequireUtil.fromRelative(script.Parent, {"ModelResolver"})
 ModelResolver = RequireUtil.must(ModelResolver, "LoomDesigner/ModelResolver")
 
-local SegmentBuilder = RequireUtil.fromRelative(script.Parent, {"SegmentBuilder"})
-SegmentBuilder = RequireUtil.must(SegmentBuilder, "LoomDesigner/SegmentBuilder")
-
 local LoomDesigner = {}
 
 -- current working state used by the designer
@@ -154,8 +151,23 @@ function LoomDesigner.RebuildPreview(_container)
 
         local pp = model.PrimaryPart or model:FindFirstChildWhichIsA("BasePart", true)
         local pivot = pp and pp.Position or Vector3.new()
-        local count = #model:GetDescendants()
-        print(string.format("Spawned PreviewBranch at %s with %d parts", tostring(pivot), count))
+        local basePartCount = 0
+        for _, d in ipairs(model:GetDescendants()) do
+                if d:IsA("BasePart") then basePartCount += 1 end
+        end
+        print(string.format("Spawned PreviewBranch at %s with %d BaseParts", tostring(pivot), basePartCount))
+        if basePartCount == 0 then
+                VisualScene.Spawn({
+                        name="DebugSegment",
+                        shape=Enum.PartType.Ball,
+                        size=Vector3.new(0.8,0.8,0.8),
+                        cframe=CFrame.new(0,3,0),
+                        color=Color3.fromRGB(255,0,0),
+                        anchored=true,
+                        canCollide=false,
+                })
+                warn("[LoomDesigner] Render produced 0 BaseParts; placed DebugSegment for visibility.")
+        end
 end
 
 -- Simple validation that checks for expected field types. Returns true if the

--- a/plugin/LoomDesigner/SegmentBuilder.lua
+++ b/plugin/LoomDesigner/SegmentBuilder.lua
@@ -2,6 +2,33 @@
 local RequireUtil = require(script.Parent.RequireUtil)
 local SegmentBuilder = {}
 
+function SegmentBuilder.BuildSegment(opts)
+    local p = Instance.new("Part")
+    p.Name = "Segment"
+    p.Anchored = (opts.anchored ~= false)
+    p.CanCollide = (opts.canCollide == true)
+    p.Material = opts.material or Enum.Material.SmoothPlastic
+    if opts.color then p.Color = opts.color end
+
+    local t = math.max(0.05, opts.thickness or 0.5)
+    local L = math.max(0.05, opts.length or 1)
+
+    local pt = opts.partType or Enum.PartType.Ball
+    if pt == Enum.PartType.Ball then
+        p.Shape = Enum.PartType.Ball
+        p.Size = Vector3.new(t, t, t)
+    elseif pt == Enum.PartType.Cylinder then
+        p.Shape = Enum.PartType.Cylinder
+        p.Size = Vector3.new(t, L, t)
+    else
+        p.Shape = Enum.PartType.Block
+        p.Size = Vector3.new(t, L, t)
+    end
+
+    if opts.cframe then p.CFrame = opts.cframe end
+    return p
+end
+
 -- Builds a single segment Instance according to materialization mode.
 -- params = {
 --   mode = "Model" | "Part",

--- a/plugin/LoomDesigner/VisualScene.lua
+++ b/plugin/LoomDesigner/VisualScene.lua
@@ -1,51 +1,75 @@
 --!strict
-local RequireUtil = require(script.Parent.RequireUtil)
 local VisualScene = {}
+local _previewModel: Model? = nil
+local _firstBasePart: BasePart? = nil
 
-local previewModel: Model? = nil
-
-function VisualScene.GetPreviewRoot()
-    local ws = game:GetService("Workspace")
-    local root = ws:FindFirstChild("LoomPreview")
-    if not root then
-        root = Instance.new("Folder")
-        root.Name = "LoomPreview"
-        root.Parent = ws
-    end
-    return root
+function VisualScene.SetPreviewModel(m: Model)
+    _previewModel = m
+    _firstBasePart = nil
 end
 
-function VisualScene.SetPreviewModel(model: Model)
-    previewModel = model
+local function ensurePrimary(part: BasePart)
+    if _previewModel and not _previewModel.PrimaryPart then
+        _previewModel.PrimaryPart = part
+    end
 end
 
 function VisualScene.Clear()
-    if previewModel then
-        for _, c in ipairs(previewModel:GetChildren()) do
-            c:Destroy()
-        end
+    if not _previewModel then return end
+    for _, ch in ipairs(_previewModel:GetChildren()) do
+        if ch:IsA("BasePart") or ch:IsA("Model") then ch:Destroy() end
     end
 end
 
-function VisualScene.Spawn(instance, cf)
-    local root = previewModel or VisualScene.GetPreviewRoot()
-    if cf then
-        -- Apply CFrame to Models or Parts
-        if instance:IsA("Model") then
-            if not instance.PrimaryPart then
-                -- Try to set a primary part automatically
-                local pp = instance:FindFirstChildWhichIsA("BasePart", true)
-                if pp then instance.PrimaryPart = pp end
-            end
-            if instance.PrimaryPart then
-                instance:PivotTo(cf)
-            end
-        elseif instance:IsA("BasePart") then
-            instance.CFrame = cf
-            instance.Anchored = true
+-- Accepts either:
+--   - an Instance (BasePart/Model) to parent
+--   - a spec table:
+--       { class="Part", shape="Ball"/Enum.PartType.Ball, size=Vector3, cframe=CFrame,
+--         material=Enum.Material.SmoothPlastic, color=Color3, anchored=true, canCollide=false, name="Segment" }
+function VisualScene.Spawn(spec)
+    if not _previewModel then return nil end
+
+    if typeof(spec) == "Instance" then
+        spec.Parent = _previewModel
+        if spec:IsA("BasePart") then ensurePrimary(spec) end
+        return spec
+    end
+    if type(spec) ~= "table" then return nil end
+
+    local part = Instance.new("Part")
+    part.Name = spec.name or "Segment"
+    part.Anchored = (spec.anchored ~= false)
+    part.CanCollide = (spec.canCollide == true)
+    part.Material = (typeof(spec.material) == "EnumItem" and spec.material) or Enum.Material.SmoothPlastic
+    if spec.color then
+        local c = spec.color
+        if typeof(c) == "Color3" then part.Color = c end
+    end
+
+    -- Shape + Size
+    local shape = spec.shape
+    if typeof(shape) == "EnumItem" then
+        part.Shape = shape
+    elseif type(shape) == "string" then
+        local s = shape:lower()
+        if s == "ball" or s == "sphere" or s == "round" then
+            part.Shape = Enum.PartType.Ball
+        elseif s == "cylinder" or s == "tube" then
+            part.Shape = Enum.PartType.Cylinder
+        else
+            part.Shape = Enum.PartType.Block
         end
     end
-    instance.Parent = root
+    if typeof(spec.size) == "Vector3" then
+        part.Size = spec.size
+    end
+    if typeof(spec.cframe) == "CFrame" then
+        part.CFrame = spec.cframe
+    end
+
+    part.Parent = _previewModel
+    ensurePrimary(part)
+    return part
 end
 
 return VisualScene

--- a/src/client/growth/GrowthVisualizer.luau
+++ b/src/client/growth/GrowthVisualizer.luau
@@ -29,13 +29,6 @@ do
     if not GrowthProfiles then error("[GrowthVisualizer] Could not resolve GrowthProfiles") end
 end
 
-local SegmentBuilder
-do
-    local root = script and script:FindFirstAncestor("LoomDesigner")
-    if root and root:FindFirstChild("SegmentBuilder") then
-        SegmentBuilder = require(root.SegmentBuilder)
-    end
-end
 local function clamp(v, mn, mx)
     if v < mn then return mn end
     if v > mx then return mx end
@@ -124,6 +117,32 @@ local function getVisual(loomUid)
     return v
 end
 
+local function renderSegments(scene, cfg, segments)
+    if not scene or not scene.Spawn then
+        return
+    end
+    for _, seg in ipairs(segments) do
+        local shape = cfg.partType or Enum.PartType.Ball
+        local size
+        if shape == Enum.PartType.Ball then
+            size = Vector3.new(seg.thickness, seg.thickness, seg.thickness)
+        else
+            size = Vector3.new(seg.thickness, seg.length, seg.thickness)
+        end
+        scene.Spawn({
+            class = "Part",
+            shape = shape,
+            size = size,
+            cframe   = seg.cframe,
+            material = cfg.material or Enum.Material.SmoothPlastic,
+            color    = cfg.color,
+            anchored = true,
+            canCollide = false,
+            name = "Segment",
+        })
+    end
+end
+
 function GrowthVisualizer.Render(container, loomState)
     local config = LoomConfigs[loomState.configId]
     if not config then return end
@@ -188,36 +207,26 @@ function GrowthVisualizer.Render(container, loomState)
     end
 
     -- === Rendering to Workspace via scene API ===
-    if not loomState.scene then return end
+    local scene = loomState.scene
+    if scene and scene.Clear then scene.Clear() end
 
-    loomState.scene.Clear()
-
-    local currentCF = CFrame.new(0,0,0)
-    for i, seg in ipairs(segments) do
-        if seg.fill > 0 then
-            local inst = SegmentBuilder and SegmentBuilder.Build({
-                mode = matOverrides.mode or "Model",
-                depth = i-1,
-                isTerminal = (i == segCount),
-                modelConfig = matOverrides.model,
-                partConfig = matOverrides.part,
-                resolver = { ResolveFromList = loomState.scene.ResolveModel },
-                configModels = config.models,
-                lengthScale = seg.lengthScale,
-                thicknessScale = seg.thicknessScale,
-            })
-            if inst then
+    if scene and scene.Spawn then
+        local cfg = matOverrides.part or {}
+        local segOut = {}
+        local currentCF = CFrame.new(0,0,0)
+        local baseLength = cfg.baseLength or 2
+        local baseThickness = cfg.baseThickness or 1
+        for i, seg in ipairs(segments) do
+            if seg.fill > 0 then
                 local rot = CFrame.Angles(math.rad(seg.pitch), math.rad(seg.yaw), math.rad(seg.roll))
-                local baseLength = 2
-                if matOverrides.mode == "Part" and matOverrides.part and matOverrides.part.baseLength then
-                    baseLength = matOverrides.part.baseLength
-                end
                 local length = baseLength * seg.lengthScale
+                local thickness = baseThickness * seg.thicknessScale
                 local stepCF = currentCF * rot * CFrame.new(0, length/2, 0)
-                loomState.scene.Spawn(inst, stepCF)
+                segOut[#segOut+1] = {cframe = stepCF, length = length, thickness = thickness}
                 currentCF = stepCF * CFrame.new(0, length/2, 0)
             end
         end
+        renderSegments(scene, cfg, segOut)
     end
 end
 


### PR DESCRIPTION
## Summary
- render growth segments in editor by spawning configured Part instances
- add SegmentBuilder.BuildSegment helper and robust VisualScene spawning
- log BasePart count and drop a debug segment when nothing is rendered

## Testing
- `lua spec/economy_spec.lua`

------
https://chatgpt.com/codex/tasks/task_e_68a2fa22f20083278af0f37f7d44d300