### PR TITLE
Expose GrowthVisualizer plugin version

### DIFF
--- a/plugin/growth/GrowthVisualizer.lua
+++ b/plugin/growth/GrowthVisualizer.lua
@@ -54,6 +54,7 @@ local function clamp(v, mn, mx)
     return v
 end
 local GrowthVisualizer = {}
+GrowthVisualizer._PLUGIN_VERSION = _PLUGIN_VERSION
 
 -- visual state keyed by loomUid
 -- each entry: {segments = { {yaw,pitch,roll,lengthScale,thicknessScale,fill}, ...}}

--- a/src/client/growth/GrowthVisualizer.luau
+++ b/src/client/growth/GrowthVisualizer.luau
@@ -54,6 +54,7 @@ local function clamp(v, mn, mx)
     return v
 end
 local GrowthVisualizer = {}
+GrowthVisualizer._PLUGIN_VERSION = _PLUGIN_VERSION
 
 -- visual state keyed by loomUid
 -- each entry: {segments = { {yaw,pitch,roll,lengthScale,thicknessScale,fill}, ...}}


### PR DESCRIPTION
## Summary
- expose plugin version from both GrowthVisualizer modules so Main.lua can log it

## Testing
- `lua spec/economy_spec.lua`
- `lua - <<'EOF'
local f = assert(io.open('plugin/growth/GrowthVisualizer.lua','r'))
local content = f:read('*a')
f:close()
local version = content:match('_PLUGIN_VERSION%s*=%s*"([^"]+)"')
print('[LoomDesigner] GrowthVisualizer:', version)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68a30cf95830832796e47c08928693d1