### PR TITLE
feat: add growth override toggles and renderer fixes

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -78,13 +78,8 @@ end
 
 local function deepMerge(dst, src)
         for k, v in pairs(src) do
-                if type(v) == "table" then
-                        local sub = dst[k]
-                        if type(sub) ~= "table" then
-                                sub = {}
-                                dst[k] = sub
-                        end
-                        deepMerge(sub, v)
+                if type(v) == "table" and type(dst[k]) == "table" then
+                        deepMerge(dst[k], v)
                 else
                         dst[k] = v
                 end
@@ -93,6 +88,15 @@ end
 
 function LoomDesigner.SetOverrides(overrides)
         deepMerge(state.overrides, overrides)
+end
+
+function LoomDesigner.ClearOverride(path)
+        local t = state.overrides
+        for i = 1, #path - 1 do
+                t = t[path[i]]
+                if type(t) ~= "table" then return end
+        end
+        t[path[#path]] = nil
 end
 
 local function ensurePreviewParent()

--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -279,7 +279,7 @@ checkbox(secSeed, "Seed affects jitter", true, function(val)
     LoomDesigner.RebuildPreview(nil)
 end)
 
-checkbox(secSeed, "Seed affects twist", true, function(val)
+checkbox(secSeed, "Seed affects Twist", true, function(val)
     LoomDesigner.SetOverrides({seedAffects = {twist = val}})
     LoomDesigner.RebuildPreview(nil)
 end)
@@ -361,8 +361,13 @@ if n then setPath("chaoticR", n) end
 end)
 
 labeledTextBox(secPath, "Micro Jitter Deg", "2", function(txt)
-local n = tonumber(txt)
-if n then setPath("microJitterDeg", n) end
+    local n = tonumber(txt)
+    if n then setPath("microJitterDeg", n) end
+end)
+
+checkbox(secPath, "Enable Heading Jitter", true, function(val)
+    LoomDesigner.SetOverrides({enableMicroJitter = val})
+    LoomDesigner.RebuildPreview(nil)
 end)
 
 -- === Segment Geometry ===
@@ -457,6 +462,11 @@ local function updateProfileVis()
     if powerBox then powerBox.Parent.Visible = bell end
 end
 
+checkbox(secScale, "Enable Size Jitter", true, function(val)
+    LoomDesigner.SetOverrides({enableScaleJitter = val})
+    LoomDesigner.RebuildPreview(nil)
+end)
+
 dropdown(secScale, popupHost, "Mode", {"constant","linear_down","linear_up","bell","inverse_bell"}, 1, function(opt)
     currentProfile.mode = opt
     commitProfile()
@@ -493,7 +503,7 @@ powerBox = labeledTextBox(secScale, "Power", "2", function(txt)
     if n then currentProfile.power = n; commitProfile() end
 end)
 
-checkbox(secScale, "Enable Size Jitter", true, function(val)
+checkbox(secScale, "Profile Jitter", true, function(val)
     currentProfile.enableJitter = val
     commitProfile()
 end)
@@ -584,15 +594,13 @@ end)
 
 -- === Rotation Rules ===
 dropdown(secRot, popupHost, "Continuity", {"Auto", "Accumulate", "Absolute"}, 1, function(opt)
-    local val
     if opt == "Accumulate" then
-        val = "accumulate"
+        LoomDesigner.SetOverrides({rotationRules = {continuity = "accumulate"}})
     elseif opt == "Absolute" then
-        val = "absolute"
+        LoomDesigner.SetOverrides({rotationRules = {continuity = "absolute"}})
     else
-        val = false
+        LoomDesigner.ClearOverride({"rotationRules","continuity"})
     end
-    LoomDesigner.SetOverrides({rotationRules = {continuity = val}})
     LoomDesigner.RebuildPreview(nil)
 end)
 
@@ -600,6 +608,11 @@ labeledTextBox(secRot, "Yaw Clamp Deg", "", function(txt)
 local n = tonumber(txt)
 LoomDesigner.SetOverrides({rotationRules = {yawClampDeg = n}})
 LoomDesigner.RebuildPreview(nil)
+end)
+
+checkbox(secRot, "Enable Twist", true, function(val)
+    LoomDesigner.SetOverrides({enableTwist = val})
+    LoomDesigner.RebuildPreview(nil)
 end)
 
 labeledTextBox(secRot, "Pitch Clamp Deg", "", function(txt)

--- a/spec/growth_visualizer_spec.lua
+++ b/spec/growth_visualizer_spec.lua
@@ -61,4 +61,24 @@ assert(segsC[1].yaw * segsC[2].yaw > 0 and segsC[2].yaw * segsC[3].yaw < 0, "zig
 local segsD = render(4, {segmentCount = 5, scaleProfile = {mode = "linear_down", start = 1, finish = 0.5, enableJitter = false}})
 assert(segsD[1].lengthScale > segsD[5].lengthScale, "size profile failed")
 
+-- Heading jitter toggle
+local segsE = render(5, {segmentCount = 3, path = {style = "straight", microJitterDeg = 5}, enableMicroJitter = false})
+for _, seg in ipairs(segsE) do
+    assert(seg.yaw == 0 and seg.pitch == 0, "heading jitter toggle failed")
+end
+
+-- Twist toggle
+local segsF = render(6, {segmentCount = 3, enableTwist = false, rotationRules = {extraRollPerSegDeg = 20, randomRollRangeDeg = 50}})
+for _, seg in ipairs(segsF) do
+    assert(seg.roll == 0, "twist disabled failed")
+end
+local segsG = render(7, {segmentCount = 3, enableTwist = true, rotationRules = {extraRollPerSegDeg = 10, randomRollRangeDeg = 0}})
+assert(segsG[1].roll == 10, "twist enabled failed")
+
+-- Scale jitter toggle
+local segsH = render(8, {segmentCount = 3, enableScaleJitter = false})
+for _, seg in ipairs(segsH) do
+    assert(seg.lengthScale == 1 and seg.thicknessScale == 1, "scale jitter toggle failed")
+end
+
 print("growth_visualizer_spec.lua ok")


### PR DESCRIPTION
## Summary
- deep-merge overrides and allow clearing individual fields
- add UI toggles for heading jitter, twist, size jitter, and continuity
- honor overrides in GrowthVisualizer with deterministic profiles and debug info

## Testing
- `lua spec/growth_visualizer_spec.lua` *(fails: command not found)*
- `lua spec/economy_spec.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4140aab208327a9055abdebfb47b3