### PR TITLE
Seed-driven growth profiles and safer visualizer

### DIFF
--- a/plugin/LoomDesigner.lua
+++ b/plugin/LoomDesigner.lua
@@ -1,0 +1,32 @@
+local LoomDesigner = {}
+
+local function serialize(v)
+    if type(v) == "table" then
+        local parts = {}
+        for k,val in pairs(v) do
+            local key
+            if type(k) == "string" and k:match("^%a[%w_]*$") then
+                key = k .. " = "
+            else
+                key = "[" .. serialize(k) .. "] = "
+            end
+            parts[#parts+1] = key .. serialize(val)
+        end
+        return "{" .. table.concat(parts, ",") .. "}"
+    elseif type(v) == "string" then
+        return string.format("%q", v)
+    else
+        return tostring(v)
+    end
+end
+
+function LoomDesigner.ExportConfig(cfg, path)
+    local f = io.open(path, "w")
+    if not f then return false end
+    local wrapped = {[cfg.id] = cfg}
+    f:write("return " .. serialize(wrapped))
+    f:close()
+    return true
+end
+
+return LoomDesigner

--- a/src/shared/looms/GrowthProfiles.luau
+++ b/src/shared/looms/GrowthProfiles.luau
@@ -10,78 +10,105 @@ local function clamp(num, min, max)
     return num
 end
 
+local function clampExpArg(x)
+    -- Prevent math.exp overflow/underflow; 60 ~ e^60 ≈ 1.1e26 (safe double)
+    if x > 60 then return 60 end
+    if x < -60 then return -60 end
+    return x
+end
+
+local function seededSign(rng)
+    return (rng:NextInteger(0, 1) == 0) and -1 or 1
+end
+
 local function rotStraight(_prof, _rng, _state)
     return {yaw = 0, pitch = 0, roll = 0}
 end
 
 local function rotCurved(prof, rng, state)
+    -- cache per-render macro params so all segments share them
+    if not state._curved then
+        state._curved = {
+            phase = rng:NextNumber(0, 2*math.pi),
+            dir   = seededSign(rng),
+        }
+    end
     state.t = (state.t or 0) + 1
     local i, N = state.t, prof.maxSegments or 24
-    local t = (i-1) / math.max(1, N-1)
-    state.phase = state.phase or rng:NextNumber(0, 2 * math.pi)
-    state.dir = state.dir or (rng:NextNumber() < 0.5 and -1 or 1)
-    local phase = state.phase
-    local dir = state.dir
-    local amp = prof.amplitudeDeg or 10
-    local sweep = math.sin(t * math.pi * (prof.frequency or 1) + phase) * amp
-    local env = (1 - (2*t-1)^2) ^ (prof.curvature or 0.35)
+    local t = (i-1)/math.max(1, N-1)
+
+    local amp  = prof.amplitudeDeg or 12
+    local freq = prof.frequency or 1
+    local curv = prof.curvature or 0.35
+
+    local sweep = math.sin(t*math.pi*freq + state._curved.phase) * amp
+    local env   = (1 - (2*t - 1)^2) ^ curv
     return {
-        yaw = dir * sweep * env,
-        pitch = dir * (amp * 0.35) * env,
-        roll = 0,
+        yaw   = state._curved.dir * sweep * env,
+        pitch = state._curved.dir * (amp * 0.35) * env,
+        roll  = prof.rollBias or 0,
     }
 end
 
 local function rotZigzag(prof, rng, state)
-    state.count = (state.count or 0) + 1
-    local runLen = prof.zigzagEvery or 1
-    state.sign = state.sign or (rng:NextNumber() < 0.5 and -1 or 1)
-    if state.count > runLen then
-        state.count = 1
-        state.sign = -state.sign
+    if not state._zz then
+        state._zz = { sign = seededSign(rng), left = 0 }
     end
-    local step = prof.zigzagStep or prof.amplitudeDeg or 10
-    return {
-        yaw = state.sign * step,
-        pitch = prof.pitchBias or 0,
-        roll = prof.rollBias or 0,
-    }
+    local runLen = math.max(1, prof.zigzagEvery or 1)
+    if state._zz.left <= 0 then
+        state._zz.sign = -state._zz.sign
+        state._zz.left = runLen
+    end
+    state._zz.left = state._zz.left - 1
+    local amp = (prof.zigzagStep or prof.amplitudeDeg or 12)
+    return { yaw = state._zz.sign * amp, pitch = prof.pitchBias or 0, roll = prof.rollBias or 0 }
 end
 
 local function rotNoise(prof, rng, _state)
     local amp = prof.noiseAmp or (prof.amplitudeDeg or 10)
     return {
-        yaw = rng:NextNumber(-amp, amp),
-        pitch = rng:NextNumber(-0.6 * amp, 0.6 * amp),
-        roll = 0,
+        yaw   = rng:NextNumber(-amp, amp),
+        pitch = rng:NextNumber(-0.6*amp, 0.6*amp),
+        roll  = prof.rollBias or 0,
     }
 end
 
 local function rotSigmoid(prof, rng, state)
-    state.count = (state.count or 0) + 1
-    local i, N = state.count, prof.maxSegments or 24
-    local t = (i-1) / math.max(1, N-1)
-    state.k = state.k or (prof.sigmoidK or 6) + rng:NextNumber(-1, 1)
-    state.mid = state.mid or (prof.sigmoidMid or 0.5) + rng:NextNumber(-0.1, 0.1)
-    local s = 1 / (1 + math.exp(-state.k * (t - state.mid)))
+    if not state._sig then
+        -- vary slope and midpoint per seed for visible differences
+        local kBase  = prof.sigmoidK or 6
+        local k      = kBase * rng:NextNumber(0.8, 1.25)     -- slope variance
+        local mid    = (prof.sigmoidMid or 0.5) + rng:NextNumber(-0.1, 0.1)
+        state._sig   = { k = k, mid = clamp(mid, 0.15, 0.85), dir = seededSign(rng) }
+    end
+    state.sCount = (state.sCount or 0) + 1
+    local i, N = state.sCount, prof.maxSegments or 24
+    local t = (i-1)/math.max(1, N-1)
+
     local amp = prof.amplitudeDeg or 10
+    local x   = clampExpArg(-state._sig.k * (t - state._sig.mid))
+    local s   = 1 / (1 + math.exp(x))  -- safe logistic
+    -- Centered outputs: yaw spans [-amp, amp], pitch peaks near the middle
     return {
-        yaw = (s - 0.5) * 2 * amp,
+        yaw   = state._sig.dir * (s - 0.5) * 2 * amp,
         pitch = (0.5 - math.abs(s - 0.5)) * 2 * (amp * 0.4),
-        roll = 0,
+        roll  = prof.rollBias or 0,
     }
 end
 
 local function rotChaotic(prof, rng, state)
-    state.x = state.x or rng:NextNumber(0.2, 0.8)
+    if not state._ch then
+        state._ch = { x = rng:NextNumber(0.2, 0.8) }
+    end
     local r = prof.chaoticR or 3.9
-    state.x = r * state.x * (1 - state.x)
-    local x = state.x
-    local amp = prof.amplitudeDeg or 10
+    local x = state._ch.x
+    x = r * x * (1 - x)
+    state._ch.x = x
+    local amp = prof.amplitudeDeg or 12
     return {
-        yaw = (x - 0.5) * 2 * amp,
-        pitch = 0,
-        roll = 0,
+        yaw   = (x - 0.5) * 2 * amp,
+        pitch = (0.5 - math.abs(x - 0.5)) * 2 * (amp * 0.4),
+        roll  = prof.rollBias or 0,
     }
 end
 


### PR DESCRIPTION
## Summary
- make growth profile rotations seed-dependent with clamped exponent math
- auto-select continuity, guard NaNs and invalid scales in growth visualizer
- add minimal LoomDesigner stub for tests

## Testing
- `lua spec/economy_spec.lua`
- `lua spec/growth_visualizer_spec.lua`
- `lua spec/loom_growth_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a43f413ddc8327bd15082f88a67048