### PR TITLE
Reset growth visualizer state for deterministic previews

### DIFF
--- a/plugin/growth/GrowthVisualizer.lua
+++ b/plugin/growth/GrowthVisualizer.lua
@@ -311,9 +311,18 @@ function GrowthVisualizer.Render(container, loomState)
     -- resolve profile and clamp
     local profile = overrides.profile or (config.profileDefaults or {kind = "curved"})
     profile = GrowthProfiles.clampProfile(profile)
-    local state = v._profileState or {}
+    -- ensure per-render state starts clean so deterministic RNG streams
+    local state = {
+        seed = loomState.baseSeed or 0,
+        t = 0,
+        sCount = 0,
+        _curved = nil,
+        _sig = nil,
+        _zz = nil,
+        _ch = nil,
+        dir = nil,
+    }
     v._profileState = state
-    state.seed = loomState.baseSeed or 0
 
     -- RNG streams
     local rngMicro = SeedUtil.rng(loomState.baseSeed or 0, "micro")

--- a/src/client/growth/GrowthVisualizer.luau
+++ b/src/client/growth/GrowthVisualizer.luau
@@ -311,9 +311,18 @@ function GrowthVisualizer.Render(container, loomState)
     -- resolve profile and clamp
     local profile = overrides.profile or (config.profileDefaults or {kind = "curved"})
     profile = GrowthProfiles.clampProfile(profile)
-    local state = v._profileState or {}
+    -- reset per-branch state each render for determinism
+    local state = {
+        seed = loomState.baseSeed or 0,
+        t = 0,
+        sCount = 0,
+        _curved = nil,
+        _sig = nil,
+        _zz = nil,
+        _ch = nil,
+        dir = nil,
+    }
     v._profileState = state
-    state.seed = loomState.baseSeed or 0
 
     -- RNG streams
     local rngMicro = SeedUtil.rng(loomState.baseSeed or 0, "micro")


### PR DESCRIPTION
## Summary
- reset per-render profile state so growth previews are deterministic

## Testing
- `lua spec/economy_spec.lua`
- `lua spec/growth_visualizer_spec.lua` (fails: Could not resolve GrowthProfiles)
- `lua spec/loom_growth_spec.lua` (fails: module 'looms/GrowthProfiles' uses Luau syntax unsupported by Lua)


------
https://chatgpt.com/codex/tasks/task_e_68a453b6625883279fce4eadcdaddd3f