### PR TITLE
Harden LoomDesigner config selection and move helpers

### DIFF
--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -231,13 +231,26 @@ local secIO        = makeSection(scroll, "Export / Import")
 
 -- Config dropdown (list from LoomConfigs keys)
 local LoomConfigs = require(game.ReplicatedStorage.looms.LoomConfigs)
-local configIds = {}
-for id, _ in pairs(LoomConfigs) do table.insert(configIds, id) end
-table.sort(configIds)
+local LoomConfigUtil = require(game.ReplicatedStorage.looms.LoomConfigUtil)
+
+local function listConfigIds()
+    local ids = {}
+    for k, v in pairs(LoomConfigs) do
+        if type(v) == "table" then table.insert(ids, k) end
+    end
+    table.sort(ids)
+    return ids
+end
+
+local configIds = listConfigIds()
 
 dropdown(secConfig, popupHost, "Config", configIds, 1, function(id)
-LoomDesigner.SetConfigId(id)
-LoomDesigner.RebuildPreview(nil)
+    if type(LoomConfigs[id]) ~= "table" then
+        warn("[LoomDesigner] Ignoring non-table config key: " .. tostring(id))
+    else
+        LoomDesigner.SetConfigId(id)
+        LoomDesigner.RebuildPreview(nil)
+    end
 end)
 
 local seedLabel
@@ -771,7 +784,7 @@ local function duplicateProfile()
     local base = selectedProfile .. "Copy"
     local i = 1
     while st.savedProfiles[base..i] do i += 1 end
-    local src = LoomConfigs._deepCopy(st.savedProfiles[selectedProfile])
+    local src = LoomConfigUtil.deepCopy(st.savedProfiles[selectedProfile])
     LoomDesigner.CreateProfile(base..i, src)
     selectedProfile = base..i
     renderProfiles()

--- a/src/shared/looms/LoomConfigUtil.luau
+++ b/src/shared/looms/LoomConfigUtil.luau
@@ -1,0 +1,38 @@
+--!strict
+-- returns a pure table (no Roblox types)
+local Util = {}
+
+function Util.deepCopy(t, seen)
+    if type(t) ~= "table" then return t end
+    seen = seen or {}
+    if seen[t] then return seen[t] end
+    local nt = {}
+    seen[t] = nt
+    for k, v in pairs(t) do
+        nt[Util.deepCopy(k, seen)] = Util.deepCopy(v, seen)
+    end
+    return nt
+end
+
+-- shallow merge of b into a (new table)
+function Util.safeMerge(a, b)
+    local out = {}
+    for k, v in pairs(a or {}) do out[k] = v end
+    for k, v in pairs(b or {}) do out[k] = v end
+    return out
+end
+
+-- merge-with-arrays: copies arrays by value
+function Util.mergeConfig(baseCfg, authored)
+    local cfg = Util.deepCopy(baseCfg or {})
+    for k, v in pairs(authored or {}) do
+        if type(v) == "table" then
+            cfg[k] = Util.deepCopy(v)
+        else
+            cfg[k] = v
+        end
+    end
+    return cfg
+end
+
+return Util

--- a/src/shared/looms/LoomConfigs.luau
+++ b/src/shared/looms/LoomConfigs.luau
@@ -178,34 +178,4 @@ local configs = {
     },
 }
 
--- Utility for plugin authoring: deep copy and safe merge helpers
-local function deepCopy(v)
-    if type(v) ~= "table" then return v end
-    local c = {}
-    for k, val in pairs(v) do
-        c[k] = deepCopy(val)
-    end
-    return c
-end
-
-local function safeMerge(dst, src)
-    if type(dst) ~= "table" or type(src) ~= "table" then return dst end
-    for k, v in pairs(src) do
-        if type(v) == "table" then
-            local t = dst[k]
-            if type(t) == "table" then
-                safeMerge(t, v)
-            else
-                dst[k] = deepCopy(v)
-            end
-        else
-            dst[k] = v
-        end
-    end
-    return dst
-end
-
-configs._deepCopy = deepCopy
-configs._safeMerge = safeMerge
-
 return configs


### PR DESCRIPTION
## Summary
- Move deep copy and merge helpers into new `LoomConfigUtil` module
- Export only config tables from `LoomConfigs`
- Resolve and validate `configId` in LoomDesigner to avoid function indexing
- Filter config dropdown to table entries and use new util for profile duplication

## Testing
- `lua spec/economy_spec.lua`
- `rojo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a46e37303083278238134b6d33ce5c