### PR TITLE
Implement deterministic Aether and economy subsystems

### DIFF
--- a/src/server/Aether.luau
+++ b/src/server/Aether.luau
@@ -1,287 +1,153 @@
-local ok, ReplicatedStorage = pcall(function()
-    return game:GetService("ReplicatedStorage")
-end)
-local okHttp, HttpServiceInst = pcall(function()
-    return game:GetService("HttpService")
-end)
-local HttpService = okHttp and HttpServiceInst or {
-    GenerateGUID = function()
-        return tostring(math.random(1, 1e8))
-    end
-}
+--!strict
+
+local Economy
+if script and script.Parent then
+    Economy = require(script.Parent:WaitForChild("Economy"))
+else
+    Economy = require("Economy")
+end
 
 local Aether = {}
 
-local InventoryBridge
-if script and script.Parent then
-    InventoryBridge = require(script.Parent:WaitForChild("InventoryBridge"))
-else
-    InventoryBridge = require("InventoryBridge")
+Aether.callbacks = {
+    onSettle = function() end,
+    onProducerAdded = function() end,
+    onProducerToggled = function() end,
+}
+
+local function now()
+    if type(time) == "function" then
+        return time()
+    end
+    return os.clock()
 end
 
-local function MakeUid()
-    return HttpService:GenerateGUID(false):sub(1, 8)
-end
-
-local function MakeDebugName(producerType, uid)
-    return producerType .. "-" .. uid:sub(1, 3)
-end
-
-local function CalcEffectiveRate(producer)
-    if not producer.active then
-        return 0
-    end
-    local baseWithAdd = math.max(0, producer.baseRate + (producer.addBonus or 0))
-    local multFactor = math.max(0, producer.multBonus or 1)
-    return baseWithAdd * multFactor
-end
-
-function Aether.Settle(player, now)
-    now = now or time()
-    local aether = player.aether
-    local dt = now - aether.lastSettleTs
-    if dt < 0 then
-        aether.lastSettleTs = now
-        return
-    end
-
-    if dt <= 1e-4 then
-        return
-    end
-    
-    local current = aether.current
-    local eff = Aether.GetEffectiveStats(player)
-    local target = eff.target
-    local rate = eff.totalRate
-
-    if current >= target then
-        local excess = current - target
-        local decayed = excess * math.exp(-aether.decayRate * dt)
-        current = target + decayed
-    else
-        current = math.min(target, current + rate * dt)
-    end
-
-    if aether.current < target and current == target then
-        aether.hitCapacity = true
-    end
-
-    aether.current = current
-    aether.lastSettleTs = now
-
-    print("Settled aether for player", player.id, "- Current:", current, "Rate:", rate, "dt:", dt)
-end
-
-function Aether.RebuildTotalRate(player)
-    local total = 0
-    for _, producer in pairs(player.producers or {}) do
-        total = total + CalcEffectiveRate(producer)
-    end
-    player.aether.totalRate = total
-    return total
-end
-
-function Aether.GetBaseStats(player)
+local function ensure(player)
+    player.aether = player.aether or {}
     local a = player.aether
-    return {
-        target = a.target,
-        purityBase = a.purityBase,
-        totalRate = a.totalRate,
-    }
-end
-
-function Aether.GetEffectiveStats(player)
-    local base = Aether.GetBaseStats(player)
-    local mods = InventoryBridge.GetDerivedAetherModifiers(player)
-    return {
-        target = base.target + (mods.target_add or 0),
-        purity = base.purityBase + (mods.purity_add or 0),
-        totalRate = base.totalRate * (mods.rate_mult or 1),
-    }
+    a.current = a.current or 0
+    a.target = a.target or 20
+    a.decayRate = a.decayRate or 0.08
+    a.purityBase = a.purityBase or 0.55
+    a.totalRate = a.totalRate or 0
+    a.lastSettleTs = a.lastSettleTs or now()
+    player.producers = player.producers or {}
 end
 
 function Aether.Init(player)
-    if not player.aether then
-        player.aether = {
-            current = 0,
-            target = 20,
-            decayRate = 0.08,
-            purityBase = 0.55,
-            totalRate = 0,
-            lastSettleTs = time(),
-        }
-    end
-    if not player.producers then
-        player.producers = {}
-    end
-    
-    Aether.RebuildTotalRate(player)
-    Aether.Settle(player)
-    
-    return Aether.Snapshot(player)
+    ensure(player)
+    player.aether.lastSettleTs = now()
 end
 
-function Aether.AddProducer(player, producerType, baseRate, patchId)
-    Aether.Settle(player)
-    
-    baseRate = baseRate or (math.random() * 0.4 + 0.4)
-    local uid = MakeUid()
-    
-    local producer = {
-        uid = uid,
-        type = producerType,
-        debugName = MakeDebugName(producerType, uid),
-        patch = patchId,
-        baseRate = baseRate,
-        addBonus = 0,
-        multBonus = 1,
-        active = true,
-        tags = "",
-    }
-    
-    player.producers[uid] = producer
-    player.aether.totalRate = player.aether.totalRate + CalcEffectiveRate(producer)
-    
-    return uid, producer.debugName
+function Aether.Settle(player, tNow)
+    ensure(player)
+    local a = player.aether
+    local t = tNow or now()
+    local dt = t - (a.lastSettleTs or t)
+    if dt <= 0 then
+        a.lastSettleTs = t
+        return
+    end
+
+    local current = a.current
+    local target = a.target
+    local rate = a.totalRate
+    local k = a.decayRate
+    local newCurrent = current
+
+    if current < target then
+        local inc = math.max(0, rate) * dt
+        newCurrent = math.min(target, current + inc)
+        if newCurrent >= target and current < target then
+            a.hitCapacity = true
+        end
+    elseif current > target then
+        local over = current - target
+        local over2 = over * math.exp(-k * dt)
+        newCurrent = target + over2
+    end
+
+    a.current = newCurrent
+    a.lastSettleTs = t
+    Aether.callbacks.onSettle(dt, (current < target and "fill" or current > target and "decay" or "idle"))
+end
+
+local uidCounter = 0
+local function nextUid()
+    uidCounter = uidCounter + 1
+    return "prod_" .. tostring(uidCounter)
+end
+
+function Aether.AddProducer(player, kind, rate)
+    ensure(player)
+    local uid = nextUid()
+    player.producers[uid] = { kind = kind, rate = rate, active = true }
+    player.aether.totalRate = player.aether.totalRate + rate
+    Aether.callbacks.onProducerAdded(kind, rate)
+    return uid
 end
 
 function Aether.RemoveProducer(player, uid)
-    Aether.Settle(player)
-    
-    local producer = player.producers[uid]
-    if not producer then
+    ensure(player)
+    local p = player.producers[uid]
+    if not p then
         return false
     end
-    
-    player.aether.totalRate = player.aether.totalRate - CalcEffectiveRate(producer)
+    if p.active then
+        player.aether.totalRate = player.aether.totalRate - p.rate
+    end
     player.producers[uid] = nil
-    
     return true
 end
 
 function Aether.SetProducerActive(player, uid, active)
-    Aether.Settle(player)
-    
-    local producer = player.producers[uid]
-    if not producer then
+    ensure(player)
+    local p = player.producers[uid]
+    if not p then
         return false
     end
-    
-    local oldRate = CalcEffectiveRate(producer)
-    producer.active = active
-    local newRate = CalcEffectiveRate(producer)
-    
-    player.aether.totalRate = player.aether.totalRate + (newRate - oldRate)
-    
+    if p.active == active then
+        return true
+    end
+    p.active = active
+    if active then
+        player.aether.totalRate = player.aether.totalRate + p.rate
+    else
+        player.aether.totalRate = player.aether.totalRate - p.rate
+    end
+    Aether.callbacks.onProducerToggled(uid, active)
     return true
 end
 
-function Aether.SetProducerRate(player, uid, baseRate, addBonus, multBonus)
+function Aether.ApplyBurst(player, amount)
+    ensure(player)
     Aether.Settle(player)
-    
-    local producer = player.producers[uid]
-    if not producer then
-        return false
-    end
-    
-    local oldRate = CalcEffectiveRate(producer)
-    producer.baseRate = baseRate or producer.baseRate
-    producer.addBonus = addBonus or producer.addBonus
-    producer.multBonus = multBonus or producer.multBonus
-    local newRate = CalcEffectiveRate(producer)
-    
-    player.aether.totalRate = player.aether.totalRate + (newRate - oldRate)
-    
-    return true
-end
-
-function Aether.ApplyBurst(player, value)
-    Aether.Settle(player)
-    player.aether.current = player.aether.current + value
-end
-
-function Aether.TryApplyInventoryBurst(player)
-    local ok, burstValue = InventoryBridge.TryConsumeBurst(player, {})
-    if ok and burstValue > 0 then
-        Aether.ApplyBurst(player, burstValue)
-        return true, burstValue
-    end
-    return false, 0
+    player.aether.current = player.aether.current + amount
 end
 
 function Aether.RequestSell(player)
     Aether.Settle(player)
-    local Economy
-    if script and script.Parent then
-        Economy = require(script.Parent:WaitForChild("Economy"))
-    else
-        Economy = require("Economy")
-    end
-    local gain = Economy.SellAether(player)
-    return gain
-end
-
-function Aether.ApplyUpgrade(player, upgradeId)
-    Aether.Settle(player)
-    local Config
-    if ReplicatedStorage then
-        Config = require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
-    else
-        Config = require("Config")
-    end
-    local upgrade = Config.UpgradeById[upgradeId]
-    
-    if not upgrade then
-        return false
-    end
-    
-    local aether = player.aether
-    if upgrade.affects == "target" then
-        aether.target = aether.target + upgrade.value
-    elseif upgrade.affects == "purityBase" then
-        aether.purityBase = aether.purityBase + upgrade.value
-    elseif upgrade.affects == "decayRate" then
-        aether.decayRate = aether.decayRate + upgrade.value
-    end
-    
-    return true
+    return Economy.SellAether(player)
 end
 
 function Aether.Snapshot(player)
-    local eff = Aether.GetEffectiveStats(player)
+    ensure(player)
+    local a = player.aether
     local snap = {
-        current = player.aether.current,
-        target = eff.target,
-        totalRate = eff.totalRate,
-        decayRate = player.aether.decayRate,
-        purityBase = eff.purity,
-        serverNow = time(),
+        current = a.current,
+        target = a.target,
+        totalRate = a.totalRate,
+        decayRate = a.decayRate,
+        purityBase = a.purityBase,
+        serverNow = now(),
         v = 1,
     }
-    if player.aether.hitCapacity then
+    if a.hitCapacity then
         snap.atCap = true
-        player.aether.hitCapacity = nil
+        a.hitCapacity = nil
     end
     return snap
 end
 
-function Aether.ListProducers(player, filter)
-    local producers = {}
-    for uid, producer in pairs(player.producers or {}) do
-        if not filter or producer.type:find(filter) or producer.debugName:find(filter) then
-            table.insert(producers, {
-                uid = uid,
-                debugName = producer.debugName,
-                type = producer.type,
-                rate = CalcEffectiveRate(producer),
-                active = producer.active,
-            })
-        end
-    end
-    
-    table.sort(producers, function(a, b) return a.rate > b.rate end)
-    
-    return producers, player.aether.totalRate
-end
-
 return Aether
+

--- a/src/server/Economy.luau
+++ b/src/server/Economy.luau
@@ -1,148 +1,125 @@
-local ok, Config = pcall(function()
-    local ReplicatedStorage = game:GetService("ReplicatedStorage")
-    return require(ReplicatedStorage:WaitForChild("Shared"):WaitForChild("Config"))
-end)
-if not ok then
+--!strict
+
+local Config
+if script and script.Parent then
+    Config = require(script.Parent.Parent.Parent.shared.Config)
+else
     Config = require("Config")
-end
-
-local okAether, Aether = pcall(function()
-    if script and script.Parent then
-        return require(script.Parent:WaitForChild("Aether"))
-    else
-        return require("Aether")
-    end
-end)
-if not okAether then
-    Aether = require("Aether")
-end
-
-local MAX_DELTA = 1e9
-local RATE_WINDOW = 5
-local RATE_MAX = 10
-
-local rateLimits = {}
-local lastAetherSell = {}
-
-local function clamp(value, min, max)
-    if value < min then
-        return min
-    end
-    if value > max then
-        return max
-    end
-    return value
 end
 
 local Economy = {}
 
-function Economy.ApplyCrumbsDelta(player, delta, reason)
-    if not Config.ReasonWhitelist[reason] then
-        return false
+local function now()
+    if type(time) == "function" then
+        return time()
     end
-    if math.abs(delta) > MAX_DELTA then
-        return false
-    end
-    local now = os.clock()
-    local bucket = rateLimits[player] or {}
-    local newBucket = {}
-    for _, t in ipairs(bucket) do
-        if now - t < RATE_WINDOW then
-            table.insert(newBucket, t)
+    return os.clock()
+end
+
+local function ensure(player)
+    player.crumbs = player.crumbs or 0
+    player.inventory = player.inventory or {}
+    player.upgrades = player.upgrades or {}
+    player.aether = player.aether or { current = 0, target = 20, decayRate = 0.08, purityBase = 0.55 }
+    player.timestamps = player.timestamps or {}
+end
+
+local function withinRateLimit(player)
+    local cfg = Config.Economy
+    local window = cfg.CRUMBS_RATE_LIMIT_WINDOW_SEC
+    local nowTs = now()
+    local ts = player.timestamps
+    local j, n = 1, #ts
+    for i = 1, n do
+        if nowTs - ts[i] <= window then
+            ts[j] = ts[i]
+            j = j + 1
         end
     end
-    if #newBucket >= RATE_MAX then
-        rateLimits[player] = newBucket
+    for k = j, n do
+        ts[k] = nil
+    end
+    if #ts >= cfg.CRUMBS_RATE_LIMIT_WINDOW_N then
         return false
     end
-    table.insert(newBucket, now)
-    rateLimits[player] = newBucket
+    ts[#ts + 1] = nowTs
+    return true
+end
 
-    player.crumbs = (player.crumbs or 0) + delta
-    print("ApplyCrumbsDelta", player.id or "unknown", delta, reason)
+function Economy.ApplyCrumbsDelta(player, delta, reason)
+    ensure(player)
+    local cfg = Config.Economy
+    if not cfg.REASONS[reason] then
+        return false
+    end
+    if not withinRateLimit(player) then
+        return false
+    end
+    player.crumbs = player.crumbs + delta
     return true
 end
 
 function Economy.SellAether(player)
-    local aether = player.aether or {}
-    local current = aether.current or 0
-    if current <= 0 then
-        return 0
-    end
-    local now = os.clock()
-    local last = lastAetherSell[player]
-    if last and now - last < 0.5 then
-        return 0
-    end
-    local stats = Aether.GetEffectiveStats(player)
-    local purity = clamp(stats.purity, 0.10, 1.00)
-    local gain = math.floor(current * purity * Config.SELL_MULT)
+    ensure(player)
+    local cfg = Config.Economy
+    local a = player.aether
+    local gain = math.floor((a.current or 0) * (a.purityBase or 0.55) * cfg.AETHER_PER_UNIT_PRICE)
+    a.current = 0
     if gain <= 0 then
         return 0
     end
-    local success = Economy.ApplyCrumbsDelta(player, gain, "sell_aether")
-    if success then
-        aether.current = 0
-        aether.lastSettleTs = time()
-        lastAetherSell[player] = now
+    if Economy.ApplyCrumbsDelta(player, gain, "sell_aether") then
         return gain
     end
     return 0
 end
 
-function Economy.SellItem(player, itemId, qty)
-    if qty <= 0 then
+function Economy.SellItem(player, itemId, count)
+    ensure(player)
+    local cfg = Config.Economy
+    count = math.max(0, math.floor(count or 0))
+    if count == 0 then
         return 0
     end
-    local item = Config.ItemById[itemId]
-    if not item then
+    local itemCfg = cfg.Items[itemId]
+    if not itemCfg then
         return 0
     end
-    local inv = player.inventory or {}
+    local inv = player.inventory
     local have = inv[itemId] or 0
-    if have < qty then
+    if have < count then
         return 0
     end
-    local gain = item.sell_value * qty
-    inv[itemId] = have - qty
-    local success = Economy.ApplyCrumbsDelta(player, gain, "sell_item")
-    if not success then
+    local gain = itemCfg.price * count
+    inv[itemId] = have - count
+    if Economy.ApplyCrumbsDelta(player, gain, "sell_item") then
+        return gain
+    else
         inv[itemId] = have
         return 0
     end
-    return gain
 end
 
 function Economy.PurchaseUpgrade(player, upgradeId)
-    local upgrade = Config.UpgradeById[upgradeId]
-    if not upgrade then
-        return false
-    end
-    local prereq = upgrade.prereq
-    if prereq and not player.upgrades[prereq] then
+    ensure(player)
+    local cfg = Config.Economy
+    local up = cfg.Upgrades[upgradeId]
+    if not up then
         return false
     end
     if player.upgrades[upgradeId] then
         return false
     end
-    local cost = upgrade.cost
-    if player.crumbs < cost then
+    if player.crumbs < up.cost then
         return false
     end
-    local ok = Economy.ApplyCrumbsDelta(player, -cost, "purchase")
-    if not ok then
+    if not Economy.ApplyCrumbsDelta(player, -up.cost, "grant") then
         return false
-    end
-    local aether = player.aether
-    if upgrade.affects == "target" then
-        aether.target = (aether.target or 0) + upgrade.value
-    elseif upgrade.affects == "purityBase" then
-        aether.purityBase = (aether.purityBase or 0) + upgrade.value
-    elseif upgrade.affects == "decayRate" then
-        aether.decayRate = (aether.decayRate or 0) + upgrade.value
     end
     player.upgrades[upgradeId] = true
+    player.aether.purityBase = (player.aether.purityBase or 0.55) + (up.purityDelta or 0)
     return true
 end
 
 return Economy
+

--- a/src/shared/Config.luau
+++ b/src/shared/Config.luau
@@ -1,39 +1,24 @@
+--!strict
+
 local Config = {}
 
-Config.ReasonWhitelist = {
-    sell_aether = true,
-    sell_item = true,
-    purchase = true,
-    refund = true,
-    grant = true,
+Config.Economy = {
+    AETHER_PER_UNIT_PRICE = 8,
+    CRUMBS_RATE_LIMIT_WINDOW_N = 10,
+    CRUMBS_RATE_LIMIT_WINDOW_SEC = 60,
+    REASONS = {
+        grant = true,
+        purchase_refund = true,
+        sell_aether = true,
+        sell_item = true,
+    },
+    Items = {
+        polished_crystal = { price = 150 },
+    },
+    Upgrades = {
+        purity_plus005 = { cost = 200, purityDelta = 0.05 },
+    },
 }
-
-Config.SELL_MULT = 8
-Config.DEFAULT_CATEGORY = "producers"
-
-
-Config.ItemConfig = {
-    { id = "shiny_pebble", displayName = "Shiny Pebble", sell_value = 10, stackable = true },
-    { id = "copper_nugget", displayName = "Copper Nugget", sell_value = 20, stackable = true },
-    { id = "silver_chunk", displayName = "Silver Chunk", sell_value = 50, stackable = true },
-    { id = "gold_ingot", displayName = "Gold Ingot", sell_value = 100, stackable = true },
-    { id = "polished_crystal", displayName = "Polished Crystal", sell_value = 150, stackable = true },
-}
-
-Config.ItemById = {}
-for _, item in ipairs(Config.ItemConfig) do
-    Config.ItemById[item.id] = item
-end
-
-Config.UpgradeConfig = {
-    { id = "target_plus10", affects = "target", value = 10, cost = 100 },
-    { id = "purity_plus005", affects = "purityBase", value = 0.05, cost = 200 },
-    { id = "decay_minus001", affects = "decayRate", value = -0.01, cost = 150 },
-}
-
-Config.UpgradeById = {}
-for _, up in ipairs(Config.UpgradeConfig) do
-    Config.UpgradeById[up.id] = up
-end
 
 return Config
+


### PR DESCRIPTION
## Summary
- Rewrite Aether module with deterministic settlement, producer bookkeeping, bursts, snapshots and sell handoff
- Add rate limited Economy layer to sell aether or items and purchase upgrades
- Provide Config module defining economy constants, item prices and upgrade effects

## Testing
- `lua spec/aether_spec.lua`
- `lua spec/economy_spec.lua`
- `lua spec/aether_integration_spec.lua` *(fails: service not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a47c4daf7483278ff57b3cd9af6dac