### PR TITLE
Fix reseed preview and sync authoring UI layout

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -198,6 +198,7 @@ end
 -- simple profile helpers ----------------------------------------------------
 function LoomDesigner.CreateProfile(name: string, profile)
         state.savedProfiles[name] = profile or { kind = "straight", segmentCountMin = 1, segmentCountMax = 1 }
+        ensureTrunk(state)
 end
 
 function LoomDesigner.DeleteProfile(name: string)
@@ -250,11 +251,7 @@ local function rebuildLibraries()
 end
 
 local function applyAuthoring()
-        if state.branchAssignments and (not state.branchAssignments.trunkProfile or state.branchAssignments.trunkProfile == "") then
-                local firstName
-                for n in pairs(state.savedProfiles or {}) do firstName = firstName or n end
-                state.branchAssignments.trunkProfile = firstName or "trunk"
-        end
+        ensureTrunk(state)
         local cfgId = resolveConfigId(LoomConfigs, state.configId)
         if not cfgId then return end
         state.configId = cfgId
@@ -306,7 +303,10 @@ end
 LoomDesigner.ApplyAuthoring = applyAuthoring
 
 function LoomDesigner.Reseed()
-        return LoomDesigner.RandomizeSeed()
+        state.baseSeed = LoomDesigner.RandomizeSeed()
+        LoomDesigner.ApplyAuthoring()
+        LoomDesigner.RebuildPreview(nil)
+        return state.baseSeed
 end
 
 local function ensurePreviewParent()


### PR DESCRIPTION
## Summary
- refresh preview when reseeding and ensure authoring state is applied
- keep trunk profile valid when creating or applying profiles
- rework model and decoration UIs to use proper layouts and edit profile drafts

## Testing
- `aftman install` *(fails: command not found)*
- `rojo build -o "skyhunters.rbxlx"` *(fails: command not found)*
- `lua spec/economy_spec.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a51d97ad70832789083a6613191487