### PR TITLE
Prefer plugin LoomConfig modules and add safe deepCopy

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -10,19 +10,33 @@ local GrowthVisualizer = RequireUtil.fromRelative(script.Parent.Parent, {"growth
 GrowthVisualizer = RequireUtil.must(GrowthVisualizer, "growth/GrowthVisualizer")
 print("[LoomDesigner] GrowthVisualizer:", GrowthVisualizer._PLUGIN_VERSION or "unknown")
 
-local LoomConfigs = RequireUtil.fromReplicatedStorage({"looms","LoomConfigs"})
-    or RequireUtil.fromRelative(script.Parent.Parent, {"looms","LoomConfigs"})
+local LoomConfigs = RequireUtil.fromRelative(script.Parent.Parent, {"looms","LoomConfigs"})
+    or RequireUtil.fromReplicatedStorage({"looms","LoomConfigs"})
 LoomConfigs = RequireUtil.must(LoomConfigs, "looms/LoomConfigs")
 
-local LoomConfigUtil = RequireUtil.fromReplicatedStorage({"looms","LoomConfigUtil"})
-    or RequireUtil.fromRelative(script.Parent.Parent, {"looms","LoomConfigUtil"})
+local LoomConfigUtil = RequireUtil.fromRelative(script.Parent.Parent, {"looms","LoomConfigUtil"})
+    or RequireUtil.fromReplicatedStorage({"looms","LoomConfigUtil"})
 LoomConfigUtil = RequireUtil.must(LoomConfigUtil, "looms/LoomConfigUtil")
+print("[LoomDesigner] Using LoomConfigUtil.deepCopy:", type(LoomConfigUtil and LoomConfigUtil.deepCopy))
 
 local VisualScene = RequireUtil.fromRelative(script.Parent, {"VisualScene"})
 VisualScene = RequireUtil.must(VisualScene, "LoomDesigner/VisualScene")
 
 local ModelResolver = RequireUtil.fromRelative(script.Parent, {"ModelResolver"})
 ModelResolver = RequireUtil.must(ModelResolver, "LoomDesigner/ModelResolver")
+
+-- Forward declare so we can use local deepCopy inside DC even if it’s defined later
+local deepCopy
+
+-- DC: resilient deep copy that uses LoomConfigUtil if available, else local
+local function DC(v)
+    local f = LoomConfigUtil and LoomConfigUtil.deepCopy
+    if type(f) == "function" then
+        return f(v)
+    end
+    -- fall back to local deepCopy (defined below)
+    return deepCopy and deepCopy(v) or v
+end
 
 local LoomDesigner = {}
 
@@ -108,12 +122,14 @@ end
 
 function LoomDesigner.Start(plugin)
         print("LoomDesigner plugin started", plugin)
-        GrowthVisualizer.SetEditorMode(true)
+        if GrowthVisualizer and type(GrowthVisualizer.SetEditorMode) == "function" then
+                GrowthVisualizer.SetEditorMode(true)
+        end
         -- Bootstrap one profile if none exist
         if next(state.savedProfiles or {}) == nil then
                 LoomDesigner.CreateProfile("profile1", { kind = "curved", segmentCountMin = 1, segmentCountMax = 1 })
                 state.profileDrafts = state.profileDrafts or {}
-                state.profileDrafts["profile1"] = LoomConfigUtil.deepCopy(state.savedProfiles["profile1"])
+                state.profileDrafts["profile1"] = DC(state.savedProfiles["profile1"])
                 state.activeProfileName = "profile1"
                 ensureTrunk(state)
                 LoomDesigner.CommitProfileEdit("profile1", state.profileDrafts["profile1"])
@@ -159,7 +175,7 @@ local function deepMerge(dst, src)
         end
 end
 
-local function deepCopy(v)
+deepCopy = function(v)
         if type(v) ~= "table" then return v end
         local copy = {}
         for k, val in pairs(v) do
@@ -190,7 +206,7 @@ function LoomDesigner.CommitProfileEdit(draftName: string, draftTable: table)
                         local k = tostring(draftTable.kind):lower()
                         draftTable.kind = SUPPORTED_KINDS[k] and k or "curved"
                 end
-                st.savedProfiles[draftName] = LoomConfigUtil.deepCopy(draftTable)
+                st.savedProfiles[draftName] = DC(draftTable)
         end
         ensureTrunk(st)
 
@@ -289,7 +305,7 @@ local function applyAuthoring()
                         byDepth = state.modelsByDepth,
                         decorations = (state.overrides and state.overrides.decorations and state.overrides.decorations.enabled)
                                 and state.overrides.decorations.types
-                                or (base.models and LoomConfigUtil.deepCopy(base.models.decorations)) or nil,
+                                or (base.models and DC(base.models.decorations)) or nil,
                 },
                 overrides = state.overrides,
         }
@@ -371,7 +387,9 @@ function LoomDesigner.RebuildPreview(_container)
         model.Parent = parent
         VisualScene.SetPreviewModel(model)
 
-        GrowthVisualizer.Release(nil, 0)
+        if GrowthVisualizer and type(GrowthVisualizer.Release) == "function" then
+                GrowthVisualizer.Release(nil, 0)
+        end
         local ok, err = pcall(function()
                 GrowthVisualizer.Render(nil, {
                         loomUid = 0,

--- a/plugin/LoomDesigner/ModelResolver.lua
+++ b/plugin/LoomDesigner/ModelResolver.lua
@@ -59,7 +59,7 @@ function ModelResolver.ResolveOne(ref)
         local have = {}
         if folder then
             for _, ch in ipairs(folder:GetChildren()) do
-                table.insert(have, ch.Name .. "(" .. ch.ClassName .. ")")
+                table.insert(have, string.format("%s(%s)", ch.Name, ch.ClassName))
             end
         end
         warn(("ModelResolver: missing model '%s' in %s; have: [%s]")
@@ -70,7 +70,7 @@ function ModelResolver.ResolveOne(ref)
         if cached then
             return cached:Clone()
         end
-        local ok, got = pcall(game.GetObjects, game, "rbxassetid://" .. tostring(ref))
+        local ok, got = pcall(game.GetObjects, game, string.format("rbxassetid://%s", tostring(ref)))
         if ok and got and got[1] then
             local inst = got[1]
             if inst:IsA("Model") or inst:IsA("Folder") or inst:IsA("BasePart") then
@@ -78,10 +78,10 @@ function ModelResolver.ResolveOne(ref)
                 return inst:Clone()
             end
         end
-        warn("ModelResolver: failed to load asset id " .. tostring(ref))
+        warn(("ModelResolver: failed to load asset id %s"):format(tostring(ref)))
         return nil
     else
-        warn("ModelResolver: unsupported ref type " .. type(ref))
+        warn(("ModelResolver: unsupported ref type %s"):format(type(ref)))
         return nil
     end
 end

--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -479,23 +479,24 @@ local function parseVector3(s: any): Vector3
 end
 
 local function parseColor3(s)
-if typeof(s) == "Color3" then return s end
-s = tostring(s):lower():gsub("%s+", "")
-if NamedColors[s] then return NamedColors[s] end
-local r,g,b = s:match("^rgb%((%d+),(%d+),(%d+)%)$")
-if not r then
-    r,g,b = s:match("^(%d+),(%d+),(%d+)$")
-end
-if r and g and b then
-    return Color3.fromRGB(tonumber(r), tonumber(g), tonumber(b))
-end
-if s:sub(1,1) ~= "#" then s = "#" .. s end
-local hex = s:match("^#(%x%x)(%x%x)(%x%x)$")
-if hex then
-    local rr,gg,bb = s:sub(2,3), s:sub(4,5), s:sub(6,7)
-    return Color3.fromRGB(tonumber(rr,16), tonumber(gg,16), tonumber(bb,16))
-end
-return Color3.fromRGB(255,255,255)
+    if typeof(s) == "Color3" then return s end
+    s = tostring(s):lower():gsub("%s+", "")
+    if NamedColors[s] then return NamedColors[s] end
+    local r, g, b = s:match("^rgb%((%d+),(%d+),(%d+)%)$")
+    if not r then
+        r, g, b = s:match("^(%d+),(%d+),(%d+)$")
+    end
+    if r and g and b then
+        return Color3.fromRGB(tonumber(r), tonumber(g), tonumber(b))
+    end
+    if s:sub(1, 1) ~= "#" then
+        s = "#" .. s
+    end
+    local rr, gg, bb = s:match("^#(%x%x)(%x%x)(%x%x)$")
+    if rr then
+        return Color3.fromRGB(tonumber(rr, 16), tonumber(gg, 16), tonumber(bb, 16))
+    end
+    return Color3.fromRGB(255, 255, 255)
 end
 
 labeledTextBox(secGeo, "Color", "#ffffff", function(txt)


### PR DESCRIPTION
## Summary
- Prefer plugin-bundled Loom modules before ReplicatedStorage
- Add resilient DC() wrapper and use it for deep copies
- Guard GrowthVisualizer calls and sanity-print loaded deepCopy
- Fix parseColor3 hex handling and stray string concatenations

## Testing
- `aftman install` *(command not found)*
- `rojo build -o "skyhunters.rbxlx"` *(command not found)*
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a5c39b74548327bb6765c470fe5a2a