### PR TITLE
Add FlowTrace tracing and instrument Main

### DIFF
--- a/plugin/LoomDesigner/FlowTrace.lua
+++ b/plugin/LoomDesigner/FlowTrace.lua
@@ -1,0 +1,236 @@
+--!strict
+--[=[
+FlowTrace.lua - lightweight tracing utility
+Provides structured logging to observe data/control flow in the plugin.
+Each function is documented line-by-line to satisfy exhaustive
+commenting requirements.
+]=]
+
+-- create module table
+local FT = {}
+
+-- run-time configuration defaults; may be overridden via FT.init
+FT.ENABLED = true -- master switch to disable all tracing
+FT.TAG_ALLOW = nil -- optional set {tag=true} to filter logs
+FT.MAX_STR = 200 -- max length when stringifying values
+
+-- detect server/client context using RunService if available
+local context = "C" -- default assume client
+local ok, runService = pcall(function()
+    return game:GetService("RunService")
+end)
+if ok and runService then
+    -- pcall for IsServer/IsClient as they may not exist outside Roblox
+    local isServer = false
+    pcall(function()
+        isServer = runService:IsServer()
+    end)
+    context = isServer and "S" or "C"
+end
+
+-- helper to truncate long strings safely
+local function truncate(str: string): string
+    -- guard against nil; tostring converts anything
+    local s = tostring(str)
+    if #s > FT.MAX_STR then
+        -- cut to maximum and append ellipsis
+        s = s:sub(1, FT.MAX_STR) .. "..."
+    end
+    return s
+end
+
+-- simple value formatter used across logging helpers
+local function formatValue(v): string
+    local t = typeof and typeof(v) or type(v)
+    if t == "string" then
+        -- direct string: truncate if necessary
+        return truncate(v)
+    elseif t == "table" then
+        -- summarize table without iterating everything
+        local count = 0
+        for _ in pairs(v) do
+            count += 1
+            if count > 5 then break end -- cap iteration for performance
+        end
+        return string.format("{table,%d}", count)
+    else
+        -- numbers/booleans/others just tostring
+        return truncate(tostring(v))
+    end
+end
+
+-- format extras table as key=value pairs
+local function formatExtras(extras: any?): string
+    if type(extras) ~= "table" then
+        return ""
+    end
+    local parts = {}
+    for k, v in pairs(extras) do
+        parts[#parts+1] = string.format("%s=%s", truncate(k), formatValue(v))
+    end
+    return table.concat(parts, " ")
+end
+
+-- central prefix builder; uses debug info for file:line
+local function makePrefix(tag: string): string
+    local src = "?"
+    local line = "?"
+    local info = debug and debug.getinfo(3, "Sl")
+    if info then
+        src = info.short_src or src
+        line = info.currentline or line
+    end
+    local now = string.format("%.3f", os.clock())
+    return string.format("[FT][%s][%s][%s:%s][%s]", context, now, src, line, tag)
+end
+
+-- internal dispatch function used by log/warn
+local function emit(level: ("print"|"warn"), tag: string, msg: string)
+    -- skip entirely if disabled
+    if not FT.ENABLED then return end
+    -- tag filtering when TAG_ALLOW is a set of allowed tags
+    if FT.TAG_ALLOW and not FT.TAG_ALLOW[tag] then return end
+    -- choose output function based on level
+    if level == "warn" then
+        warn(msg)
+    else
+        print(msg)
+    end
+end
+
+-- public logging API ------------------------------------------------------
+
+-- FT.init(opts) : configure tracing module
+function FT.init(opts)
+    -- merge runtime overrides from global flags if present
+    if _G and _G.LD_FT_ENABLED ~= nil then
+        FT.ENABLED = _G.LD_FT_ENABLED and true or false
+    end
+    if _G and _G.LD_FT_TAGS then
+        FT.TAG_ALLOW = {}
+        for tag in tostring(_G.LD_FT_TAGS):gmatch("[^,]+") do
+            FT.TAG_ALLOW[tag] = true
+        end
+    end
+    -- apply explicit options table
+    if type(opts) == "table" then
+        if opts.enabled ~= nil then FT.ENABLED = opts.enabled end
+        if opts.maxStr ~= nil then FT.MAX_STR = opts.maxStr end
+        if opts.tagAllow ~= nil then
+            FT.TAG_ALLOW = nil
+            if type(opts.tagAllow) == "table" then
+                FT.TAG_ALLOW = {}
+                for _, tag in ipairs(opts.tagAllow) do
+                    FT.TAG_ALLOW[tag] = true
+                end
+            elseif type(opts.tagAllow) == "string" then
+                FT.TAG_ALLOW = {}
+                for tag in opts.tagAllow:gmatch("[^,]+") do
+                    FT.TAG_ALLOW[tag] = true
+                end
+            end
+        end
+    end
+end
+
+-- log helper
+function FT.log(tag: string, fmt: string, ...)
+    local prefix = makePrefix(tag)
+    local msg = string.format(fmt, ...)
+    emit("print", tag, prefix .. " " .. truncate(msg))
+end
+
+-- warn helper
+function FT.warn(tag: string, fmt: string, ...)
+    local prefix = makePrefix(tag)
+    local msg = string.format(fmt, ...)
+    emit("warn", tag, prefix .. " " .. truncate(msg))
+end
+
+-- wrapper for functions to log entry/exit/errors
+function FT.fn(tag: string, f: (any) -> any)
+    return function(...)
+        -- log entry with arguments
+        local argParts = {}
+        for i = 1, select("#", ...) do
+            argParts[i] = formatValue(select(i, ...))
+        end
+        FT.log(tag, "\226\134\146 %s", table.concat(argParts, ",")) -- →
+        -- execute function safely
+        local results = {pcall(f, ...)}
+        if results[1] then
+            -- success path: log return values
+            local ret = {}
+            for i = 2, #results do
+                ret[#ret+1] = formatValue(results[i])
+            end
+            FT.log(tag, "\226\134\148 %s", table.concat(ret, ",")) -- ←
+            return table.unpack(results, 2)
+        else
+            -- failure path: log and rethrow
+            FT.warn(tag, "\303\227 %s", formatValue(results[2])) -- ×
+            error(results[2])
+        end
+    end
+end
+
+-- wrap all function fields of a table
+function FT.traceTable(tag: string, tbl: table)
+    for k, v in pairs(tbl) do
+        if type(v) == "function" then
+            tbl[k] = FT.fn(tag .. "." .. tostring(k), v)
+        end
+    end
+    return tbl
+end
+
+-- watchTable: proxy that logs reads and writes
+function FT.watchTable(tag: string, t: table)
+    local proxy = {}
+    local meta = {}
+
+    -- log reading
+    function meta:__index(k)
+        local v = t[k]
+        FT.log(tag, "GET %s=%s", truncate(k), formatValue(v))
+        return v
+    end
+
+    -- log writing
+    function meta:__newindex(k, v)
+        local old = t[k]
+        t[k] = v
+        FT.log(tag, "SET %s %s->%s", truncate(k), formatValue(old), formatValue(v))
+    end
+
+    -- forward table functions
+    meta.__len = function()
+        return #t
+    end
+    meta.__pairs = function()
+        return pairs(t)
+    end
+    meta.__ipairs = function()
+        return ipairs(t)
+    end
+
+    return setmetatable(proxy, meta), t
+end
+
+-- branch probe
+function FT.branch(tag: string, cond: boolean, extras: table?)
+    FT.log(tag, "IF %s %s", tostring(cond), formatExtras(extras))
+    return cond
+end
+
+-- loop probe
+function FT.loop(tag: string, i: number, n: number, extras: table?)
+    FT.log(tag, "FOR %d/%d %s", i, n, formatExtras(extras))
+end
+
+-- checkpoint probe
+function FT.check(tag: string, kv: table)
+    FT.log(tag, "CHECK %s", formatExtras(kv))
+end
+
+return FT


### PR DESCRIPTION
## Summary
- implement FlowTrace tracing module with function wrappers, branch and table watchers
- wire FlowTrace into LoomDesigner Main: initialize tracing, proxy state tables, wrap helpers, and add checkpoints

## Testing
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a5d00360788327a0150a12dfa34ea1