### PR TITLE
Fix ensureTrunk forward declaration

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -29,6 +29,7 @@ ModelResolver = RequireUtil.must(ModelResolver, "LoomDesigner/ModelResolver")
 
 -- Forward declare so we can use local deepCopy inside DC even if it’s defined later
 local deepCopy
+local ensureTrunk
 
 -- DC: resilient deep copy that uses LoomConfigUtil if available, else local
 local function DC(v)
@@ -215,7 +216,7 @@ deepCopy = FT.fn("Main.deepCopy", deepCopy)
 
 local _commitTimer: thread? = nil
 
-local function ensureTrunk(st)
+function ensureTrunk(st)
         st.savedProfiles = st.savedProfiles or {}
         local first
         for n in pairs(st.savedProfiles) do first = first or n end


### PR DESCRIPTION
## Summary
- Forward declare `ensureTrunk` alongside other locals
- Define `ensureTrunk` using the forward-declared local to avoid global lookup

## Testing
- `lua spec/economy_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a5d9cfc7648327ad3cdb1c07dd15a4