### PR TITLE
Add child management to LoomDesigner profiles

### DIFF
--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -840,9 +840,7 @@ renderProfileEditor = function()
     end
 
     local function commit()
-        LoomDesigner.CommitProfileEdit(selectedProfile, draft)
-        LoomDesigner.ApplyAuthoring()
-        LoomDesigner.RebuildPreview(nil)
+        commitAndRebuild()
     end
 
     local kinds = LoomDesigner.SUPPORTED_KIND_LIST or {"straight","curved","zigzag","sigmoid","chaotic"}


### PR DESCRIPTION
## Summary
- expose child profile configuration in profile editor
- wire child changes through commitAndRebuild for live preview updates

## Testing
- `./rojo/rojo test` *(fails: Found argument 'test' which wasn't expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bd67ada483279e6923e87a6de4ed