### PR TITLE
Handle new profile textbox visibility safely

### DIFF
--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -766,20 +766,21 @@ end)
 renameBox.Parent.Visible = false
 
 local pendingProfileName = ""
-local newProfileBox = labeledTextBox(secProfilesLib, "Profile Name", "", function(txt)
+local newProfileBox
+newProfileBox = labeledTextBox(secProfilesLib, "Profile Name", "", function(txt)
     local st = LoomDesigner.GetState()
     local name = (txt ~= "" and txt) or pendingProfileName
     LoomDesigner.CreateProfile(name)
     st.profileDrafts[name] = LoomConfigUtil.deepCopy(st.savedProfiles[name])
     st.activeProfileName = name
     selectedProfile = name
-    newProfileBox.Parent.Visible = false
+    if newProfileBox and newProfileBox.Parent then newProfileBox.Parent.Visible = false end
     pendingProfileName = ""
     renderProfiles()
     commitAndRebuild()
     renderProfileEditor()
 end)
-newProfileBox.Parent.Visible = false
+if newProfileBox and newProfileBox.Parent then newProfileBox.Parent.Visible = false end
 
 local function newProfile()
     local st = LoomDesigner.GetState()


### PR DESCRIPTION
## Summary
- declare `newProfileBox` before calling `labeledTextBox`
- guard new profile text box visibility by checking for a parent before hiding

## Testing
- `./luau_dir/luau spec/aether_spec.lua` *(fails: attempt to index nil with 'path')*

------
https://chatgpt.com/codex/tasks/task_e_68a6c31917f88327b12c55ee93c963fb