### PR TITLE
Fix profile list scroll reference

### DIFF
--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -1087,7 +1087,7 @@ local function renderAssignments()
             renderProfiles()
             renderProfileEditor()
             renderAssignments()
-            local btn = profileList:FindFirstChild(name)
+            local btn = listFrame:FindFirstChild(name)
             if btn then
                 local abs = btn.AbsolutePosition
                 local rootAbs = scroll.AbsolutePosition


### PR DESCRIPTION
## Summary
- fix profile tree click scroll by using `listFrame` instead of undefined `profileList`

## Testing
- `for f in spec/*_spec.lua; do echo "Running $f"; lua "$f"; echo; done` *(some specs failed: service not available, CFrame nil)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c652ee7483279babce5675917aa1