### PR TITLE
Expose branch cap controls and document depth rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,21 @@ For more help, check out [the Rojo documentation](https://rojo.space/docs).
 ## Branching
 
 The growth system uses **branch assignments** to control which profiles spawn at each depth.
+Depth `0` represents the trunk; each generation of branches increases the depth by one.
 
 ### Existing depth-driven rules
 
 - **`perDepth`** – list of profile choices for each depth. At depth `n`, the system selects from `perDepth[n]` using weighted chances.
 - **`spacingN`** – minimum number of segments between branches at depth `n`.
 - **`maxPerDepth`** – maximum branches that may spawn at depth `n`.
+- **`branchCap`** – global limit on branch count across all depths (defaults to 2).
 
 Example:
 
 ```lua
 branchAssignments = {
   trunkProfile = "trunk",
+  branchCap = 2,
   perDepth = {
     [1] = { {name = "branchA", chance = 0.7}, {name = "branchB", chance = 0.3} },
     [2] = { {name = "twig", chance = 1.0} }
@@ -39,6 +42,8 @@ branchAssignments = {
   maxPerDepth = { [1] = 4 }
 }
 ```
+
+`spacingN` and `maxPerDepth` work together: `spacingN[n]` enforces a minimum gap between branch origins at depth `n`, while `maxPerDepth[n]` caps how many branches may appear at that depth. Once the global `branchCap` is reached, no additional branches spawn. By default the system permits two branches unless these values are overridden.
 
 ### Upcoming hierarchical model
 

--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -1060,6 +1060,22 @@ local function renderAssignments()
         renderAssignments()
     end)
 
+    labeledTextBox(secAssign, "Branch Cap", tostring(st.branchAssignments.branchCap or 2), function(txt)
+        local n = tonumber(txt)
+        if n then
+            st.branchAssignments.branchCap = math.max(0, math.floor(n))
+            LoomDesigner.ApplyAuthoring(); LoomDesigner.RebuildPreview(nil)
+        end
+    end)
+
+    labeledTextBox(secAssign, "Max per Depth", tostring(st.branchAssignments.maxPerDepth or 2), function(txt)
+        local n = tonumber(txt)
+        if n then
+            st.branchAssignments.maxPerDepth = math.max(0, math.floor(n))
+            LoomDesigner.ApplyAuthoring(); LoomDesigner.RebuildPreview(nil)
+        end
+    end)
+
     local tree = Instance.new("Frame")
     tree.BackgroundTransparency = 1
     tree.Size = UDim2.new(1,0,0,0)


### PR DESCRIPTION
## Summary
- add UI fields for global branch cap and per-depth limits in the LoomDesigner plugin
- clarify branching depth rules and spacing/max limits in documentation

## Testing
- `rojo build -o build.rbxl`


------
https://chatgpt.com/codex/tasks/task_e_68a6c653cf508327a5be601fdf69160e