### PR TITLE
Guard preview rebuild against missing profiles

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -267,7 +267,21 @@ function LoomDesigner.CommitProfileEdit(draftName: string, draftTable: table)
         if _commitTimer then task.cancel(_commitTimer) end
         _commitTimer = task.delay(0.1, function()
                 LoomDesigner.ApplyAuthoring()
-                LoomDesigner.RebuildPreview(nil)
+                local cfgId = state.configId
+                local trunkName = state.branchAssignments and state.branchAssignments.trunkProfile
+                local hasProfile = LoomConfigs
+                        and LoomConfigs[cfgId]
+                        and LoomConfigs[cfgId].profiles
+                        and LoomConfigs[cfgId].profiles[trunkName]
+                if hasProfile then
+                        LoomDesigner.RebuildPreview(nil)
+                else
+                        warn(string.format(
+                                "[LoomDesigner] Missing profile '%s' for config '%s'; skipping preview",
+                                tostring(trunkName),
+                                tostring(cfgId)
+                        ))
+                end
                 _commitTimer = nil
         end)
 end

--- a/plugin/growth/GrowthVisualizer.lua
+++ b/plugin/growth/GrowthVisualizer.lua
@@ -545,6 +545,11 @@ function GrowthVisualizer.Render(container, loomState)
 
     local trunkName = branchAssignments.trunkProfile or "trunk"
     if not profiles[trunkName] then
+        warn(string.format(
+            "[GrowthVisualizer] Missing profile '%s' in config '%s'; using 'trunk'",
+            tostring(trunkName),
+            tostring(loomState.configId)
+        ))
         profiles.trunk = profiles.trunk or (config.profileDefaults or {kind="curved"})
         trunkName = "trunk"
     end


### PR DESCRIPTION
## Summary
- Skip preview rebuild if trunk profile is missing after committing edits
- Warn in growth renderer when selected trunk profile is missing

## Testing
- ⚠️ `lua spec/aether_integration_spec.lua` (service not available)
- ⚠️ `lua spec/growth_visualizer_spec.lua` (CFrame global missing)


------
https://chatgpt.com/codex/tasks/task_e_68a6d0e731408327a6c3889bd104a17e