### PR TITLE
Handle unresolved models with detailed messages

### DIFF
--- a/plugin/LoomDesigner/ModelResolver.lua
+++ b/plugin/LoomDesigner/ModelResolver.lua
@@ -91,7 +91,11 @@ end
 
 -- Pick an entry from { "nameA", "nameB", ... } (or asset ids)
 function ModelResolver.ResolveFromList(list, opts)
-    if not list or #list == 0 then return nil end
+    if not list or #list == 0 then
+        local msg = "ModelResolver: empty list"
+        warn(msg)
+        return nil, msg
+    end
     local pick
     if opts and type(opts.select) == "function" then
         pick = opts.select(list)

--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -1201,6 +1201,7 @@ local function renderModels()
             table.insert(st.modelLibrary, ref)
             renderModels()
         else
+            warnLabel.Text = err or "Asset not found"
             warnLabel.Visible = true
         end
     end
@@ -1232,8 +1233,13 @@ local function renderModels()
         row.Size = UDim2.new(1,0,0,24)
         row.BackgroundTransparency = 1
         row.Parent = secModels
-        local inst = ModelResolver.ResolveOne(ref)
-        local nameText = inst and string.format("%s (%s)", tostring(ref), inst.Name) or tostring(ref)
+        local inst, msg = ModelResolver.ResolveOne(ref)
+        local nameText
+        if inst then
+            nameText = string.format("%s (%s)", tostring(ref), inst.Name)
+        else
+            nameText = string.format("%s (%s)", tostring(ref), msg or "unresolved")
+        end
         if inst then
             local preview = Instance.new("ViewportFrame")
             preview.Size = UDim2.new(0,24,1,0)
@@ -1310,6 +1316,14 @@ local function renderModels()
     table.sort(depths, depthLess)
     for _, depth in ipairs(depths) do
         local list = st.modelsByDepth[depth] or {}
+        local filtered = {}
+        for _, ref in ipairs(list) do
+            if ModelResolver.ResolveOne(ref) then
+                table.insert(filtered, ref)
+            end
+        end
+        list = filtered
+        st.modelsByDepth[depth] = list
         local df = Instance.new("Frame")
         df.BackgroundTransparency = 1
         df.Size = UDim2.new(1,0,0,0)
@@ -1334,8 +1348,11 @@ local function renderModels()
             row.BackgroundTransparency = 1
             row.Parent = df
             dropdown(row, popupHost, "", st.modelLibrary, table.find(st.modelLibrary, ref) or 1, function(opt)
-                list[i] = tostring(opt):gsub("^%s*(.-)%s*$","%1")
-                LoomDesigner.ApplyAuthoring(); LoomDesigner.RebuildPreview(nil)
+                local cleaned = tostring(opt):gsub("^%s*(.-)%s*$","%1")
+                if ModelResolver.ResolveOne(cleaned) then
+                    list[i] = cleaned
+                    LoomDesigner.ApplyAuthoring(); LoomDesigner.RebuildPreview(nil)
+                end
             end)
             local up = makeBtn(row, "^", function()
                 if i>1 then list[i],list[i-1]=list[i-1],list[i]; renderModels(); LoomDesigner.ApplyAuthoring(); LoomDesigner.RebuildPreview(nil) end
@@ -1361,9 +1378,11 @@ local function renderModels()
         local addBtn = makeBtn(df, "Add", function()
             local ref = st.modelLibrary[1]
             if ref == nil then return end
-            st.modelsByDepth[depth] = list
-            table.insert(list, ref)
-            renderModels(); LoomDesigner.ApplyAuthoring(); LoomDesigner.RebuildPreview(nil)
+            if ModelResolver.ResolveOne(ref) then
+                st.modelsByDepth[depth] = list
+                table.insert(list, ref)
+                renderModels(); LoomDesigner.ApplyAuthoring(); LoomDesigner.RebuildPreview(nil)
+            end
         end)
         addBtn.Size = UDim2.new(0,60,0,24)
         local hasLib = (#st.modelLibrary > 0)


### PR DESCRIPTION
## Summary
- Return explicit error messages when model lists are empty
- Show resolver errors in the model library and filter unresolved models before mapping to depths

## Testing
- `for f in spec/*.lua; do echo Running $f; lua "$f"; done` *(fails: plugin/growth/GrowthVisualizer.lua:552: attempt to index a nil value (global 'CFrame'); spec/placement_persistence_spec.lua:37: service not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d0e8f59c83278afcdd01d6e9ea59