### PR TITLE
Fix trunk profile clearing with no saved profiles

### DIFF
--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -295,6 +295,7 @@ local secIO        = makeSection(scroll, "Export / Import")
 local selectedProfile: string? = nil
 local renderProfiles
 local renderProfileEditor
+local renderAssignments
 local commitAndRebuild
 
 -- Config dropdown (list from LoomConfigs keys)
@@ -1058,11 +1059,14 @@ end
 
 renderProfiles()
 
--- re-render profiles automatically when the saved profiles table changes
+-- re-render UI automatically when the saved profiles table changes
 do
     local st = LoomDesigner.GetState()
     st.savedProfiles = select(1, FlowTrace.watchTable("ui.savedProfiles", st.savedProfiles, function()
-        task.defer(renderProfiles)
+        task.defer(function()
+            renderProfiles()
+            renderAssignments()
+        end)
     end))
 end
 
@@ -1079,7 +1083,6 @@ local function renderAssignments()
     trunkFrame.AutomaticSize = Enum.AutomaticSize.Y
     trunkFrame.Parent = secAssign
     if #names == 0 then
-        st.branchAssignments.trunkProfile = nil
         local btn = dropdown(trunkFrame, popupHost, "Trunk Profile", {"No profiles"}, 1, function() end)
         btn.Active = false
         btn.AutoButtonColor = false


### PR DESCRIPTION
## Summary
- Re-render assignments when saved profiles change
- Stop clearing trunk profile state if no profiles exist and show hint instead

## Testing
- `rojo --version` *(fails: command not found)*
- `aftman install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d53181d08327852f9608d06e62de