### PR TITLE
Handle unresolved models with errors and accessory fallback

### DIFF
--- a/plugin/LoomDesigner/ModelResolver.lua
+++ b/plugin/LoomDesigner/ModelResolver.lua
@@ -26,7 +26,18 @@ local function getModelsFolder()
 end
 
 function ModelResolver.ResolveOne(ref)
-    if type(ref) == "string" then
+    if typeof(ref) == "Instance" then
+        if ref:IsA("Model") or ref:IsA("Folder") or ref:IsA("BasePart") or ref:IsA("Accessory") then
+            return ref:Clone(), nil
+        end
+        local wrap = Instance.new("Model")
+        wrap.Name = ref.Name
+        local c = ref:Clone()
+        c.Parent = wrap
+        local pp = c:IsA("BasePart") and c or wrap:FindFirstChildWhichIsA("BasePart", true)
+        if pp then (wrap :: any).PrimaryPart = pp end
+        return wrap, nil
+    elseif type(ref) == "string" then
         local folder = getModelsFolder()
         local wanted = tostring(ref):gsub("^%s*(.-)%s*$", "%1")
         if folder then


### PR DESCRIPTION
## Summary
- Propagate model resolution errors and support in-memory instances
- Add model library fallback using player's accessories when asset IDs fail
- Prevent unresolved decoration models from being added and display row-level errors

## Testing
- `for f in spec/*_spec.lua; do echo "Running $f"; lua $f || break; done` *(fails: service not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d53108f48327b055ebf1f3545a2c