### PR TITLE
fix: guard LoomDesigner commit flow

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -255,7 +255,9 @@ function LoomDesigner.CommitProfileEdit(draftName: string, draftTable: table)
        end
        if _commitTimer then task.cancel(_commitTimer) end
 
-       local merged = applyAuthoring()
+       local f = LoomDesigner.ApplyAuthoring
+       assert(type(f) == "function", "ApplyAuthoring missing")
+       local merged = f()
        if not merged then
                warn(string.format("[LoomDesigner] Failed to merge profile '%s'; trunk unchanged", tostring(draftName)))
                return
@@ -270,7 +272,9 @@ function LoomDesigner.CommitProfileEdit(draftName: string, draftTable: table)
        end
 
        _commitTimer = task.delay(0.1, function()
-               local cfg = applyAuthoring()
+               local f = LoomDesigner.ApplyAuthoring
+               assert(type(f) == "function", "ApplyAuthoring missing")
+               local cfg = f()
                if not cfg then
                        warn(string.format("[LoomDesigner] Failed to merge profile '%s'; skipping preview", tostring(draftName)))
                        _commitTimer = nil


### PR DESCRIPTION
## Summary
- guard CommitProfileEdit against missing ApplyAuthoring implementation

## Testing
- `lua spec/ghost_preview_spec.lua`
- `luau` startup flow (fails: require path must start with valid prefix)

------
https://chatgpt.com/codex/tasks/task_e_68a6d7c997f08327afc48a15ea1a1985