### PR TITLE
feat: support child profiles

### DIFF
--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -976,7 +976,7 @@ renderProfileEditor = function()
 
     local childSec = makeSection(profileEditor, "Children")
     local PLACEMENTS = {"tip","junction","along","radial","spiral"}
-    local ROTATIONS = {"upright","inherit"}
+    local ROTATIONS = {"upright","inherit","custom"}
     local function renderChildren()
         for _, c in ipairs(childSec:GetChildren()) do
             if c:IsA("GuiObject") then c:Destroy() end
@@ -1006,10 +1006,35 @@ renderProfileEditor = function()
                 child.placement = opt
                 commit()
             end)
-            dropdown(frame, popupHost, "Rotation", ROTATIONS, table.find(ROTATIONS, child.rotation) or 1, function(opt)
-                child.rotation = opt
+            local rotIndex
+            if type(child.rotation) == "table" then
+                rotIndex = table.find(ROTATIONS, "custom")
+            else
+                rotIndex = table.find(ROTATIONS, child.rotation)
+            end
+            dropdown(frame, popupHost, "Rotation", ROTATIONS, rotIndex or 1, function(opt)
+                if opt == "custom" then
+                    child.rotation = type(child.rotation) == "table" and child.rotation or {pitch = 0, yaw = 0, roll = 0}
+                else
+                    child.rotation = opt
+                end
                 commit()
+                renderChildren()
             end)
+            if type(child.rotation) == "table" then
+                labeledTextBox(frame, "Pitch", tostring(child.rotation.pitch or 0), function(txt)
+                    child.rotation.pitch = tonumber(txt) or 0
+                    commit()
+                end)
+                labeledTextBox(frame, "Yaw", tostring(child.rotation.yaw or 0), function(txt)
+                    child.rotation.yaw = tonumber(txt) or 0
+                    commit()
+                end)
+                labeledTextBox(frame, "Roll", tostring(child.rotation.roll or 0), function(txt)
+                    child.rotation.roll = tonumber(txt) or 0
+                    commit()
+                end)
+            end
             local delBtn = makeBtn(frame, "Remove", function()
                 table.remove(draft.children, i)
                 renderChildren()


### PR DESCRIPTION
## Summary
- ensure profiles convert legacy depth rules into `children`
- recursively traverse profile children when visualizing growth
- add configurable child section with rotation controls in LoomDesigner UI

## Testing
- `lua spec/aether_integration_spec.lua` *(fails: service not available)*
- `lua spec/aether_spec.lua`
- `lua spec/bounds_xy_spec.lua`
- `lua spec/economy_spec.lua`
- `lua spec/ghost_preview_spec.lua`
- `lua spec/growth_visualizer_spec.lua` *(fails: attempt to index global 'CFrame')*
- `lua spec/held_rigidity_spec.lua`
- `lua spec/inventory_spec.lua`
- `lua spec/loom_growth_spec.lua` *(fails: attempt to index global 'CFrame')*
- `lua spec/persistence_spec.lua`
- `lua spec/placement_persistence_spec.lua` *(fails: service not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e0f6af188327b90071f8acc4e66a