### PR TITLE
feat: watch saved profiles and highlight active

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,21 @@ branchAssignments = {
 
 In this example, the trunk (depth 0) grows two `branchA` chains at depth 1.
 Each `branchA` then follows the `[1]` rules, producing one `branchB` at depth 2.
+
+## LoomDesigner UI Architecture
+
+```text
+secProfilesLib
+├─ listFrame (ScrollingFrame)
+│  ├─ profile buttons*        (*activeProfileName highlighted background)
+│  └─ newProfileBox (created only when parent exists)
+├─ buttonsRow
+│  ├─ New       -> newProfile()
+│  ├─ Duplicate -> duplicateProfile()
+│  ├─ Rename    -> renameProfile()
+│  └─ Delete    -> deleteProfile()
+└─ profileEditor
+
+state.savedProfiles --[FlowTrace.watchTable]--> renderProfiles()
+state.activeProfileName ----------------------> visual cue in listFrame
+```

--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -795,30 +795,34 @@ renameBox.Parent.LayoutOrder = 3
 
 local pendingProfileName = ""
 local newProfileBox: TextBox? = nil
-newProfileBox = labeledTextBox(secProfilesLib, "Profile Name", "", function(txt)
-    local st = LoomDesigner.GetState()
-    local name = (txt ~= "" and txt) or pendingProfileName
-    LoomDesigner.CreateProfile(name)
-    st.profileDrafts[name] = LoomConfigUtil.deepCopy(st.savedProfiles[name])
-    st.activeProfileName = name
-    selectedProfile = name
-    if newProfileBox and newProfileBox.Parent then newProfileBox.Parent.Visible = false end
-    pendingProfileName = ""
-    commitAndRebuild()
-    renderProfiles()
-    renderProfileEditor()
-    task.defer(function()
-        local btn = listFrame:FindFirstChild(name)
-        if btn then
-            local abs = btn.AbsolutePosition
-            local rootAbs = listFrame.AbsolutePosition
-            listFrame.CanvasPosition = Vector2.new(0, abs.Y - rootAbs.Y)
+if secProfilesLib and secProfilesLib.Parent then
+    newProfileBox = labeledTextBox(secProfilesLib, "Profile Name", "", function(txt)
+        local st = LoomDesigner.GetState()
+        local name = (txt ~= "" and txt) or pendingProfileName
+        LoomDesigner.CreateProfile(name)
+        st.profileDrafts[name] = LoomConfigUtil.deepCopy(st.savedProfiles[name])
+        st.activeProfileName = name
+        selectedProfile = name
+        if newProfileBox and newProfileBox.Parent then
+            newProfileBox.Parent.Visible = false
         end
+        pendingProfileName = ""
+        commitAndRebuild()
+        renderProfiles()
+        renderProfileEditor()
+        task.defer(function()
+            local btn = listFrame:FindFirstChild(name)
+            if btn then
+                local abs = btn.AbsolutePosition
+                local rootAbs = listFrame.AbsolutePosition
+                listFrame.CanvasPosition = Vector2.new(0, abs.Y - rootAbs.Y)
+            end
+        end)
     end)
-end)
-if newProfileBox and newProfileBox.Parent then
-    newProfileBox.Parent.Visible = false
-    newProfileBox.Parent.LayoutOrder = 3
+    if newProfileBox.Parent then
+        newProfileBox.Parent.Visible = false
+        newProfileBox.Parent.LayoutOrder = 3
+    end
 end
 
 local function newProfile()
@@ -1066,15 +1070,16 @@ renderProfiles = function()
         local btn = Instance.new("TextButton")
         btn.Name = name
         btn.Size = UDim2.new(0,180,0,24)
-        btn.BackgroundColor3 = Color3.fromRGB(48,48,48)
         btn.TextColor3 = Color3.new(1,1,1)
         btn.ZIndex = listFrame.ZIndex + 1
         btn.Text = name
         if name == st.activeProfileName then
+            btn.BackgroundColor3 = Color3.fromRGB(70,70,100)
             btn.Font = Enum.Font.SourceSansBold
             btn.BorderSizePixel = 2
             btn.BorderColor3 = Color3.fromRGB(80,120,200)
         else
+            btn.BackgroundColor3 = Color3.fromRGB(48,48,48)
             btn.Font = Enum.Font.SourceSans
             btn.BorderSizePixel = 0
         end
@@ -1123,8 +1128,8 @@ renderProfiles()
 
 -- re-render UI automatically when the saved profiles table changes
 do
-    local st = LoomDesigner.GetState()
-    st.savedProfiles = select(1, FlowTrace.watchTable("ui.savedProfiles", st.savedProfiles, function()
+    local state = LoomDesigner.GetState()
+    state.savedProfiles = select(1, FlowTrace.watchTable("ui.savedProfiles", state.savedProfiles, function()
         task.defer(function()
             renderProfiles()
             renderAssignments()


### PR DESCRIPTION
## Summary
- guard profile name box creation with parent checks
- highlight active profile entries and re-render list when saved profiles change
- document LoomDesigner UI tree

## Testing
- `lua spec/aether_spec.lua`
- `lua spec/aether_integration_spec.lua` *(fails: service not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fc30fab48327aa7bddda11ffa8b4