### PR TITLE
Refresh branch assignments after profile changes

### DIFF
--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -806,6 +806,7 @@ local renameBox = labeledTextBox(secProfilesLib, "New Name", "", function(txt)
         end
         selectedProfile = txt
         commitAndRebuild()
+        renderAssignments()
     end
     renameBox.Parent.Visible = false
 end)
@@ -829,6 +830,7 @@ if secProfilesLib and secProfilesLib.Parent then
         commitAndRebuild()
         renderProfiles()
         renderProfileEditor()
+        renderAssignments()
         task.defer(function()
             local btn = listFrame:FindFirstChild(name)
             if btn then
@@ -871,6 +873,7 @@ local function duplicateProfile()
     st.activeProfileName = name
     selectedProfile = name
     commitAndRebuild()
+    renderAssignments()
 end
 
 local function renameProfile()
@@ -889,6 +892,7 @@ local function deleteProfile()
     end
     selectedProfile = nil
     commitAndRebuild()
+    renderAssignments()
 end
 
 makeBtn(buttonsRow, "New", newProfile)
@@ -1045,7 +1049,8 @@ renderProfileEditor = function()
     end
 
     local function commit()
-        commitAndRebuild()
+    commitAndRebuild()
+    renderAssignments()
     end
 
     local kinds = LoomDesigner.SUPPORTED_KIND_LIST or {"straight","curved","zigzag","sigmoid","chaotic"}


### PR DESCRIPTION
## Summary
- rebuild branch assignments after creating a profile
- keep trunk dropdown synced when renaming, duplicating, or deleting profiles

## Testing
- `for f in spec/*_spec.lua; do echo Running $f; lua $f 2>&1; done | nl`


------
https://chatgpt.com/codex/tasks/task_e_68a70cb6a2a883279cf6c591a6d05ea2