### PR TITLE
Add LoomDesigner assignments API

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -480,6 +480,37 @@ function LoomDesigner.GetBranches()
         return copy
 end
 
+-- assignments API ------------------------------------------------------------
+function LoomDesigner.SetTrunk(name: string)
+        newState.assignments.trunk = name
+end
+
+function LoomDesigner.AddChild(parent: string, child: string, placement: string, count: number)
+        table.insert(newState.assignments.children, {
+                parent = parent,
+                child = child,
+                placement = placement or "tip",
+                count = count or 1,
+        })
+end
+
+function LoomDesigner.RemoveChild(idx: number)
+        table.remove(newState.assignments.children, idx)
+end
+
+function LoomDesigner.GetAssignments()
+        local copy = { trunk = newState.assignments.trunk, children = {} }
+        for i, a in ipairs(newState.assignments.children) do
+                copy.children[i] = {
+                        parent = a.parent,
+                        child = a.child,
+                        placement = a.placement,
+                        count = a.count,
+                }
+        end
+        return copy
+end
+
 -- export/import -------------------------------------------------------------
 local function rebuildLibraries()
         state.modelLibrary = {}

--- a/spec/assignments_api_spec.lua
+++ b/spec/assignments_api_spec.lua
@@ -1,0 +1,28 @@
+package.path = "plugin/?.lua;plugin/?/init.lua;src/server/?.luau;src/server/?/init.luau;src/shared/?.luau;src/shared/?/init.luau;src/client/?.luau;src/client/?/init.luau;" .. package.path
+
+local LoomDesigner = require("LoomDesigner/Main")
+
+-- ensure branches exist for assignments
+LoomDesigner.CreateBranch("trunkBranch", {kind = "straight"})
+LoomDesigner.CreateBranch("childBranch", {kind = "straight"})
+
+-- trunk assignment
+LoomDesigner.SetTrunk("trunkBranch")
+
+-- add child assignment
+LoomDesigner.AddChild("trunkBranch", "childBranch", "side", 2)
+
+local a = LoomDesigner.GetAssignments()
+assert(a.trunk == "trunkBranch", "trunk not set")
+assert(#a.children == 1, "child not added")
+assert(a.children[1].parent == "trunkBranch", "parent mismatch")
+assert(a.children[1].child == "childBranch", "child mismatch")
+assert(a.children[1].placement == "side", "placement mismatch")
+assert(a.children[1].count == 2, "count mismatch")
+
+-- remove child
+LoomDesigner.RemoveChild(1)
+local b = LoomDesigner.GetAssignments()
+assert(#b.children == 0, "child not removed")
+
+print("assignments_api_spec.lua ok")


### PR DESCRIPTION
## Summary
- add new assignments API functions for LoomDesigner
- cover assignments API with basic spec

## Testing
- `for f in spec/*_spec.lua; do echo "Running $f"; lua "$f" || { echo "Failed: $f"; break; }; done` *(fails: service not available)*
- `lua spec/loom_growth_spec.lua` *(fails: attempt to index global 'CFrame')*
- `lua spec/assignments_api_spec.lua` *(fails: error loading module 'LoomDesigner/Main')*


------
https://chatgpt.com/codex/tasks/task_e_68a716b6b8cc8327a5e25b086e775818