### PR TITLE
chore: allow LoomDesigner to load without LoomConfigs

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -24,7 +24,11 @@ local ModelResolver = RequireUtil.fromRelative(script.Parent, {"ModelResolver"})
 ModelResolver = RequireUtil.must(ModelResolver, "LoomDesigner/ModelResolver")
 
 local LoomConfigs = RequireUtil.fromRelative(script.Parent.Parent, {"looms","LoomConfigs"})
-LoomConfigs = RequireUtil.must(LoomConfigs, "looms/LoomConfigs")
+    or RequireUtil.fromReplicatedStorage({"looms","LoomConfigs"})
+if not LoomConfigs then
+    FT.warn("LC.missing", "could not resolve looms/LoomConfigs; using stub")
+    LoomConfigs = {}
+end
 
 -- Forward declare so we can use local deepCopy inside DC even if it’s defined later
 local deepCopy


### PR DESCRIPTION
## Summary
- check for `looms/LoomConfigs` locally before falling back to ReplicatedStorage
- warn and use an empty stub when `LoomConfigs` cannot be resolved

## Testing
- `lua spec/aether_spec.lua`
- `lua spec/bounds_xy_spec.lua`
- `lua spec/economy_spec.lua`
- `lua spec/ghost_preview_spec.lua`
- `lua spec/held_rigidity_spec.lua`
- `lua spec/inventory_spec.lua`
- `lua spec/persistence_spec.lua`
- `lua spec/aether_integration_spec.lua` *(fails: service not available)*
- `lua spec/assignments_api_spec.lua` *(fails: Luau syntax unsupported by Lua 5.1)*
- `lua spec/growth_visualizer_spec.lua` *(fails: missing global `CFrame`)*
- `lua spec/loom_growth_spec.lua` *(fails: missing global `CFrame`)*
- `lua spec/placement_persistence_spec.lua` *(fails: service not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b928c6b083279dc6fe6453ac5ae9