### PR TITLE
Avoid stale LoomDesigner preview configs

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -391,6 +391,9 @@ local function renderBranch(name, depth)
                        end
                end
        end
+
+       -- remove preview config after render to avoid leaks
+       LoomConfigs[cfgId] = nil
 end
 
 function LoomDesigner.RebuildPreview(_container)
@@ -401,6 +404,13 @@ function LoomDesigner.RebuildPreview(_container)
                for name in pairs(newState.branches) do
                        newState.assignments.trunk = name
                        break
+               end
+       end
+
+       -- clear any stale preview configs from previous runs
+       for id in pairs(LoomConfigs) do
+               if type(id) == "string" and id:match("^__ld_preview_") then
+                       LoomConfigs[id] = nil
                end
        end
 


### PR DESCRIPTION
## Summary
- clear old `__ld_preview_*` entries in `LoomConfigs` before building a new preview
- drop temporary preview config after each branch renders

## Testing
- `lua spec/growth_visualizer_spec.lua` *(fails: attempt to index global 'CFrame')*
- `lua spec/ghost_preview_spec.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a7b9915aa08327be83706dd632de85