### PR TITLE
Add optional reset for LoomDesigner import state

### DIFF
--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -307,8 +307,28 @@ function LoomDesigner.ExportAuthoring()
         }
 end
 
-function LoomDesigner.ImportAuthoring(cfg)
+function LoomDesigner.ImportAuthoring(cfg, reset)
         cfg = cfg or {}
+        if reset ~= false then
+                newState.modelsByDepth = {}
+                newState.modelLibrary = {}
+                newState.overrides = {
+                        materialization = { mode = "Model" },
+                        rotationRules = {},
+                        decorations = { enabled = false, types = {} },
+                }
+        end
+        if cfg.models and cfg.models.byDepth then
+                newState.modelsByDepth = DC(cfg.models.byDepth)
+        end
+        if cfg.overrides then
+                newState.overrides = DC(cfg.overrides)
+        end
+        newState.modelsByDepth = select(1, FT.watchTable("newState.modelsByDepth", newState.modelsByDepth))
+        newState.overrides = select(1, FT.watchTable("newState.overrides", newState.overrides))
+        rebuildLibraries()
+        newState.modelLibrary = select(1, FT.watchTable("newState.modelLibrary", newState.modelLibrary))
+
         newState.branches = DC(cfg.branches or {})
         newState.branches = select(1, FT.watchTable("newState.branches", newState.branches))
         newState.assignments = DC(cfg.assignments or {trunk = "", children = {}})


### PR DESCRIPTION
## Summary
- reset import authoring state for LoomDesigner to avoid stale data
- re-establish FlowTrace watchers for modelsByDepth, modelLibrary, and overrides

## Testing
- `for f in spec/*_spec.lua; do echo "Running $f"; lua "$f"; echo; done 2>&1 | nl`


------
https://chatgpt.com/codex/tasks/task_e_68a7b992f82883279001b2f9107865bd