### PR TITLE
Initialize LoomDesigner on UI build

### DIFF
--- a/docs/LoomDesigner.md
+++ b/docs/LoomDesigner.md
@@ -5,16 +5,22 @@ This guide outlines how to access the plugin's `Main` module from the Roblox Stu
 ## Accessing the `Main` Module
 
 1. In Roblox Studio, open **View → Command Bar**.
-2. Load the module:
+2. Reference the plugin folder and load the module:
 
 ```lua
 -- Require the plugin's Main module
-local LD = require(game:GetService("ServerScriptService"):WaitForChild("LoomDesigner"):WaitForChild("Main"))
+local pluginFolder = plugin:WaitForChild("LoomDesigner")
+local LD = require(pluginFolder)
+
+-- Initialize authoring state (creates default branch1)
+LD.Start(plugin)
 ```
 
-The `LD` table now exposes the plugin's authoring functions.
+The `LD` table now exposes the plugin's authoring functions. `Start` must be called once before creating or editing branches so the default profile exists.
 
 ## Examples
+
+All snippets assume `LD.Start(plugin)` has already been executed.
 
 ### CreateBranch
 Create a new branch profile:

--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -209,10 +209,13 @@ function UI.Build(_widget: PluginGui, plugin: Plugin, where)
     local selectedBranch: string? = nil
     local branchDropdownBtn: TextButton? = nil
     local function refreshBranchDropdown()
+        ensureStart()
         if branchDropdownBtn then branchDropdownBtn.Parent:Destroy() end
         local branches = (LoomDesigner.GetBranches and LoomDesigner.GetBranches()) or {}
         local names = {}
-        for name in pairs(branches) do table.insert(names, name) end
+        for name in pairs(branches) do
+            table.insert(names, name)
+        end
         table.sort(names)
         branchDropdownBtn = labeledDropdown(container, popupHost, "Branch", names, 1, function(opt)
             selectedBranch = opt


### PR DESCRIPTION
## Summary
- Ensure `LoomDesigner.Start` runs when the UI builds so the default branch is created
- Document how to require the plugin and call `Start` from the command bar

## Testing
- `lua spec/assignments_api_spec.lua` *(fails: error loading module 'LoomDesigner/Main' due to Luau syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68a8162d93888327b068e697646e6975