### PR TITLE
feat: add global loom designer controls

### DIFF
--- a/docs/LoomDesigner.md
+++ b/docs/LoomDesigner.md
@@ -47,5 +47,21 @@ Render the current authoring state in the workspace:
 LD.RebuildPreview()
 ```
 
+### Additional Controls
+
+The UI exposes fields for base seed, segment count, and rotation rules. These can also be driven from the command bar:
+
+```lua
+-- Set deterministic seed used by the preview
+LD.SetSeed(12345)
+
+-- Override the number of segments rendered in the preview
+local GSC = require(pluginFolder.GrowthStylesCore)
+GSC.SetParam("segmentCount", 12)
+
+-- Choose how segment rotations accumulate ("accumulate" or "absolute")
+LD.SetRotationContinuity("absolute")
+```
+
 These snippets can be run directly from the command bar for quick iteration without opening the plugin UI.
 

--- a/plugin/LoomDesigner/Main.lua
+++ b/plugin/LoomDesigner/Main.lua
@@ -151,6 +151,18 @@ function LoomDesigner.SetGrowthPercent(g)
         newState.g = g
 end
 
+function LoomDesigner.SetRotationContinuity(mode)
+        if mode == nil or mode == "" then
+                newState.overrides.rotationRules.continuity = nil
+        else
+                newState.overrides.rotationRules.continuity = mode
+        end
+end
+
+function LoomDesigner.GetRotationContinuity()
+        return newState.overrides.rotationRules.continuity
+end
+
 local function deepMerge(dst, src)
         for k, v in pairs(src) do
                 if type(v) == "table" and type(dst[k]) == "table" then

--- a/plugin/LoomDesigner/UI.lua
+++ b/plugin/LoomDesigner/UI.lua
@@ -25,6 +25,51 @@ local KIND_FIELDS = {
     },
 }
 
+local GLOBAL_FIELDS = {
+    {
+        kind = "number",
+        label = "Base Seed",
+        get = function()
+            return LoomDesigner.GetSeed and LoomDesigner.GetSeed()
+        end,
+        set = function(v)
+            if LoomDesigner.SetSeed then LoomDesigner.SetSeed(v) end
+        end,
+    },
+    {
+        kind = "number",
+        label = "Segment Count",
+        get = function()
+            return GrowthStylesCore.GetParam("segmentCount")
+        end,
+        set = function(v)
+            GrowthStylesCore.SetParam("segmentCount", v)
+        end,
+    },
+    {
+        kind = "dropdown",
+        label = "Rotation Rules",
+        options = {"auto","accumulate","absolute"},
+        get = function()
+            if LoomDesigner.GetRotationContinuity then
+                local mode = LoomDesigner.GetRotationContinuity()
+                if mode == "accumulate" then return 2 end
+                if mode == "absolute" then return 3 end
+            end
+            return 1
+        end,
+        set = function(opt)
+            if LoomDesigner.SetRotationContinuity then
+                if opt == "auto" then
+                    LoomDesigner.SetRotationContinuity(nil)
+                else
+                    LoomDesigner.SetRotationContinuity(opt)
+                end
+            end
+        end,
+    },
+}
+
 local function makeList(parent: Instance): Frame
     local frame = Instance.new("Frame")
     frame.BackgroundTransparency = 1
@@ -181,6 +226,19 @@ function UI.Build(_widget: PluginGui, plugin: Plugin, where)
             for _,entry in ipairs(defs) do
                 numberField(paramsFrame, entry.label, GrowthStylesCore.GetParam(entry.key), function(v)
                     GrowthStylesCore.SetParam(entry.key, v)
+                    GrowthStylesCore.ApplyPreview()
+                end)
+            end
+        end
+        for _,entry in ipairs(GLOBAL_FIELDS) do
+            if entry.kind == "number" then
+                numberField(paramsFrame, entry.label, entry.get(), function(v)
+                    entry.set(v)
+                    GrowthStylesCore.ApplyPreview()
+                end)
+            elseif entry.kind == "dropdown" then
+                labeledDropdown(paramsFrame, popupHost, entry.label, entry.options, entry.get(), function(opt)
+                    entry.set(opt)
                     GrowthStylesCore.ApplyPreview()
                 end)
             end


### PR DESCRIPTION
## Summary
- expose Base Seed, Segment Count, and Rotation Rules controls in Loom Designer UI
- add setters/getters for rotation continuity
- document new authoring controls

## Testing
- `lua spec/growth_visualizer_spec.lua` *(fails: attempt to index a nil value (global 'CFrame'))*
- `lua spec/loom_growth_spec.lua` *(skipped: missing Roblox globals)*

------
https://chatgpt.com/codex/tasks/task_e_68a820f07f408327b030393ebc5876df