### PR TITLE
Improve branch authoring flow

### DIFF
--- a/docs/LoomDesigner.md
+++ b/docs/LoomDesigner.md
@@ -49,3 +49,7 @@ LD.RebuildPreview()
 
 These snippets can be run directly from the command bar for quick iteration without opening the plugin UI.
 
+## Plugin UI Branch Creation
+
+The plugin's UI hides authoring controls until a branch is chosen. Use **Add Branch** to create a branch while staying in the current mode, or **New Branch + Author** to create a branch and immediately switch into authoring mode for it. When no branches exist, the first one you create is selected automatically.
+


### PR DESCRIPTION
## Summary
- hide branch editing controls until a branch is selected, with helper guidance
- allow creating a branch and immediately entering authoring mode
- document the streamlined branch-creation flow

## Testing
- `for f in spec/*_spec.lua; do echo Running $f; lua $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68a820f1b3f88327954bc12dc3c2198f